### PR TITLE
catch and handle error responses (e.g. 429: exceeded quota)

### DIFF
--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -88,8 +88,11 @@ class GemImg:
             return None
 
         response_data = response.json()
-        usage_metadata = response_data["usageMetadata"]
+        if err := response_data.get('error'):
+            logger.error(f"API Response Error: {err['code']} — {err['message']}")
+            return None
 
+        usage_metadata = response_data["usageMetadata"]
         # Check for prohibited content
         candidates = response_data["candidates"][0]
         finish_reason = candidates.get("finishReason")


### PR DESCRIPTION
If you're using a valid API key but without the adequate billing, etc, `response_data` will contain an `error` entry, but _not_ `usageMetadata`, which throws a `KeyError`

https://github.com/minimaxir/gemimg/blob/main/gemimg/gemimg.py#L91

```
        response_data = response.json()
        usage_metadata = response_data["usageMetadata"]

```

So check for `error`, and log the message and return:

```
        response_data = response.json()
        if err := response_data.get('error'):
            logger.error(f"API HTTP Response Error: {err.get('code')} — {err.get('message')}")
            return None
```

Sample response from the API when error code is 429:

```json
{
  "error": {
    "code": 429,
    "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/usage?tab=rate-limit. * Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_input_token_count, limit: 0, model: gemini-2.5-flash-preview-image\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-flash-preview-image\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-flash-preview-image\nPlease retry in 18.876787221s.",
    "status": "RESOURCE_EXHAUSTED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.Help",
        "links": [
          {
            "description": "Learn more about Gemini API quotas",
            "url": "https://ai.google.dev/gemini-api/docs/rate-limits"
          }
        ]
      },
      {
        "@type": "type.googleapis.com/google.rpc.QuotaFailure",
        "violations": [
          {
            "quotaMetric": "generativelanguage.googleapis.com/generate_content_free_tier_input_token_count",
            "quotaId": "GenerateContentInputTokensPerModelPerMinute-FreeTier",
            "quotaDimensions": {
              "location": "global",
              "model": "gemini-2.5-flash-preview-image"
            }
          },
          {
            "quotaMetric": "generativelanguage.googleapis.com/generate_content_free_tier_requests",
            "quotaId": "GenerateRequestsPerMinutePerProjectPerModel-FreeTier",
            "quotaDimensions": {
              "location": "global",
              "model": "gemini-2.5-flash-preview-image"
            }
          },
          {
            "quotaMetric": "generativelanguage.googleapis.com/generate_content_free_tier_requests",
            "quotaId": "GenerateRequestsPerDayPerProjectPerModel-FreeTier",
            "quotaDimensions": {
              "location": "global",
              "model": "gemini-2.5-flash-preview-image"
            }
          }
        ]
      },
      {
        "@type": "type.googleapis.com/google.rpc.RetryInfo",
        "retryDelay": "18s"
      }
    ]
  }
}
```

