### PR TITLE
feat: Add support base URL from GOOGLE_GEMINI_BASE_URL environment or base-url command-line parameter

### DIFF
--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -33,6 +33,11 @@ def main():
         "--model", default="gemini-2.5-flash-image", help="The model to use."
     )
     parser.add_argument(
+        "--base-url",
+        default=os.getenv("GOOGLE_GEMINI_BASE_URL"),
+        help="Alternative Gemini API endpoint for your organization.",
+    )
+    parser.add_argument(
         "--aspect-ratio", default="1:1", help="Aspect ratio of the generated image."
     )
     parser.add_argument(
@@ -70,7 +75,12 @@ def main():
             "API key is required. Provide it with --api-key or set the GEMINI_API_KEY environment variable."
         )
 
-    gem_img = GemImg(api_key=args.api_key, model=args.model)
+    if args.base_url:
+        base_url = args.base_url
+    else:
+        base_url = "https://generativelanguage.googleapis.com"
+
+    gem_img = GemImg(api_key=args.api_key, model=args.model, base_url=base_url)
 
     # We call generate with save=False to handle file saving manually.
     result = gem_img.generate(

--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -19,6 +19,7 @@ class GemImg:
     api_key: str = field(default=os.getenv("GEMINI_API_KEY"), repr=False)
     client: httpx.Client = field(default_factory=httpx.Client, repr=False)
     model: str = "gemini-2.5-flash-image"
+    base_url: str = "https://generativelanguage.googleapis.com"
 
     def __post_init__(self):
         if not self.api_key:
@@ -74,7 +75,7 @@ class GemImg:
         }
 
         headers = {"Content-Type": "application/json", "x-goog-api-key": self.api_key}
-        api_url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model}:generateContent"
+        api_url = f"{self.base_url}/v1beta/models/{self.model}:generateContent"
 
         try:
             response = self.client.post(


### PR DESCRIPTION
Fixes Issue #10 which asks for support for organizations that offer Google Gemini endpoints through a different base URL endpoint.

- Default behavior is exactly the same
- If the `GOOGLE_GEMINI_BASE_URL` environment variable or `--base-url` command-line parameter is provided then use that instead of the Google default.