### PR TITLE
Gemini 3 support, Google Search, multi-image I/O, and icon generation (iOS/macOS/Android/Windows/PWA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ gemimg.egg-info/
 dist/
 build/
 AGENTS.md
+.claude/
+PR_INFO.md
+.cache/
+*.pyc
+test.png
+uv.lock

--- a/README.md
+++ b/README.md
@@ -211,6 +211,43 @@ python -m gemimg "A kitten with prominent purple-and-green fur."
 
 Common options: `-i/--input-images`, `-o/--output-file`, `--aspect-ratio`, `--output-dir`, `-n` (number of images), `--webp`, `--store-prompt`, `-f/--force`. The API key can be provided via `--api-key` or the `GEMINI_API_KEY` environment variable.
 
+## Gemini 3 Pro Image Features
+
+Gemini 3 Pro Image (Nano Banana Pro) adds additional capabilities:
+
+### Google Search Grounding
+
+Use real-time data from Google Search to inform image generation:
+
+```py3
+from gemimg import GemImg
+
+g = GemImg(model="gemini-3-pro-image-preview")
+
+# Generate an image with current event context
+gen = g.generate(
+    "Create an infographic showing today's weather in Tokyo",
+    google_search=True
+)
+```
+
+CLI usage:
+```sh
+gemimg "Create an infographic showing today's weather in Tokyo" --model gemini-3-pro-image-preview --google-search
+```
+
+### Extended Input Image Support
+
+Gemini 3 Pro Image supports up to 14 input images (vs 6 for Flash models), enabling more complex compositions and style references.
+
+```py3
+# Combine multiple reference images
+gen = g.generate(
+    "Create a cohesive scene combining elements from all reference images",
+    imgs=["ref1.png", "ref2.png", "ref3.png", "ref4.png", "ref5.png", "ref6.png", "ref7.png"]
+)
+```
+
 ## Gemini 2.5 Flash Image Model Notes
 
 - Gemini 2.5 Flash Image cannot do style transfer, e.g. `turn me into Studio Ghibli`, and seems to ignore commands that try to do so. Google's [developer documentation example](https://ai.google.dev/gemini-api/docs/image-generation#3_style_transfer) of style transfer unintentionally demonstrates this by [incorrectly applying](https://x.com/minimaxir/status/1963431053193810129) the specified style. The only way to shift the style is to generate a completely new image in that style, which can still have mixed results if the source style is intrinsic.

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from .gemimg import GemImg
@@ -7,26 +8,8 @@ from .grid import Grid
 from .utils import save_image
 
 
-def main():
-    """CLI for generating images with GemImg."""
-    parser = argparse.ArgumentParser(
-        description="Generate images using the Gemini API."
-    )
-
-    parser.add_argument("prompt", help="The text prompt for image generation.")
-    parser.add_argument(
-        "-i",
-        "--input-images",
-        nargs="+",
-        help="Optional paths to input images.",
-        default=[],
-    )
-    parser.add_argument(
-        "-o",
-        "--output-file",
-        help="Optional output filename. Defaults to output.png, output-2.png, etc.",
-        default=None,
-    )
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments shared between commands."""
     parser.add_argument(
         "--api-key",
         default=os.getenv("GEMINI_API_KEY"),
@@ -40,79 +23,18 @@ def main():
         default=os.getenv("GOOGLE_GEMINI_BASE_URL"),
         help="Alternative Gemini API endpoint for your organization.",
     )
-    parser.add_argument(
-        "--aspect-ratio", default="1:1", help="Aspect ratio of the generated image."
-    )
-    parser.add_argument(
-        "--no-resize",
-        action="store_false",
-        dest="resize_inputs",
-        help="Do not resize input images.",
-    )
-    parser.add_argument(
-        "--output-dir", default="", help="Directory to save the generated images."
-    )
-    parser.add_argument(
-        "--temperature", type=float, default=1.0, help="Generation temperature."
-    )
-    parser.add_argument(
-        "--webp", action="store_true", help="Save as WEBP instead of PNG."
-    )
-    parser.add_argument("-n", type=int, default=1, help="Number of images to generate.")
-    parser.add_argument(
-        "--store-prompt",
-        action="store_true",
-        help="Store the prompt in the image metadata.",
-    )
-    parser.add_argument(
-        "--image-size",
-        default="2K",
-        help="Image size for the generation (Pro models only).",
-    )
-    parser.add_argument(
-        "--system-prompt",
-        default=None,
-        help="System prompt for the generation (Pro models only).",
-    )
-    parser.add_argument(
-        "--grid",
-        default=None,
-        help="Grid dimensions as ROWSxCOLS (e.g., 2x2). Pro models only.",
-    )
-    parser.add_argument(
-        "--grid-aspect-ratio",
-        default="1:1",
-        help="Aspect ratio for grid cells (default: 1:1).",
-    )
-    parser.add_argument(
-        "--grid-image-size",
-        default="2K",
-        help="Image size for grid generation (default: 2K).",
-    )
-    parser.add_argument(
-        "--save-grid-original",
-        action="store_true",
-        help="Save the original grid image before slicing.",
-    )
-    parser.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Force overwrite of existing files.",
-    )
 
-    args = parser.parse_args()
 
+def generate_command(args: argparse.Namespace) -> None:
+    """Handle the generate command (default behavior)."""
     if not args.api_key:
-        parser.error(
-            "API key is required. Provide it with --api-key or set the GEMINI_API_KEY environment variable."
+        print(
+            "Error: API key is required. Provide it with --api-key or set the GEMINI_API_KEY environment variable.",
+            file=sys.stderr,
         )
+        sys.exit(1)
 
-    if args.base_url:
-        base_url = args.base_url
-    else:
-        base_url = "https://generativelanguage.googleapis.com"
-
+    base_url = args.base_url or "https://generativelanguage.googleapis.com"
     gem_img = GemImg(api_key=args.api_key, model=args.model, base_url=base_url)
 
     # Parse grid dimensions if provided
@@ -128,9 +50,11 @@ def main():
                 save_original_image=args.save_grid_original,
             )
         except ValueError:
-            parser.error(
-                f"Invalid grid format '{args.grid}'. Use ROWSxCOLS (e.g., 2x2)."
+            print(
+                f"Error: Invalid grid format '{args.grid}'. Use ROWSxCOLS (e.g., 2x2).",
+                file=sys.stderr,
             )
+            sys.exit(1)
 
     # We call generate with save=False to handle file saving manually.
     result = gem_img.generate(
@@ -138,7 +62,7 @@ def main():
         imgs=args.input_images,
         aspect_ratio=args.aspect_ratio,
         resize_inputs=args.resize_inputs,
-        save=False,  # This is important
+        save=False,
         temperature=args.temperature,
         webp=args.webp,
         n=args.n,
@@ -151,36 +75,27 @@ def main():
     if result and result.images:
         ext = "webp" if args.webp else "png"
 
-        # Determine base output path and name
         output_path = Path(args.output_dir)
         if args.output_file:
             base_name = Path(args.output_file).stem
-            # If an extension is provided in the output file, it overrides the --webp flag
             if Path(args.output_file).suffix:
                 ext = Path(args.output_file).suffix[1:]
         else:
             base_name = "output"
 
-        # Create output directory if it doesn't exist
         output_path.mkdir(parents=True, exist_ok=True)
 
-        # Save the generated images
         for i, img in enumerate(result.images):
-            # Determine the initial proposed path
             if len(result.images) > 1:
-                # For multiple images, always append index
                 current_base = f"{base_name}-{i + 1}"
             else:
-                # For a single image, use the base name
                 current_base = base_name
 
             final_path = output_path / f"{current_base}.{ext}"
 
-            # If not forcing overwrite, check for existence and find a unique name
             if not args.force:
                 counter = 1
                 while final_path.exists():
-                    # If path exists, append a counter
                     final_path = output_path / f"{current_base}-{counter}.{ext}"
                     counter += 1
 
@@ -188,6 +103,275 @@ def main():
             print(f"Image saved to {final_path}")
     else:
         print("Failed to generate image.")
+
+
+def icons_command(args: argparse.Namespace) -> None:
+    """Handle the icons subcommand."""
+    from .icons import IconGenerator, IconGeneratorConfig, IconType, Platform, Preset, PRESET_PLATFORMS
+
+    if not args.api_key:
+        # API key is only required if we need to generate
+        has_all_variants = args.light and (not args.themed or (args.dark and args.tinted))
+        has_enough_inputs = len(args.input_images) >= (3 if args.themed else 1)
+
+        if not (has_all_variants or has_enough_inputs):
+            print(
+                "Error: API key is required for generation. Provide it with --api-key or set the GEMINI_API_KEY environment variable.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # Determine platforms
+    if args.platforms:
+        platforms = set()
+        for p in args.platforms:
+            try:
+                platforms.add(Platform(p.lower()))
+            except ValueError:
+                print(f"Error: Unknown platform '{p}'", file=sys.stderr)
+                sys.exit(1)
+    else:
+        try:
+            preset = Preset(args.preset.lower())
+            platforms = set(PRESET_PLATFORMS[preset])
+        except ValueError:
+            print(f"Error: Unknown preset '{args.preset}'", file=sys.stderr)
+            sys.exit(1)
+
+    # Determine icon type
+    if args.menu_icon:
+        icon_type = IconType.MENU_ICON
+    elif args.favicon:
+        icon_type = IconType.FAVICON
+    else:
+        icon_type = IconType.APP_ICON
+
+    # Create config
+    config = IconGeneratorConfig(
+        icon_type=icon_type,
+        platforms=platforms,
+        themed=args.themed,
+        macos_shadow=not args.no_shadow,
+        validate_safe_zone=not args.no_safe_zone_check,
+        output_dir=Path(args.output_dir),
+    )
+
+    # Create GemImg instance if needed
+    gemimg = None
+    if args.api_key:
+        base_url = args.base_url or "https://generativelanguage.googleapis.com"
+        gemimg = GemImg(api_key=args.api_key, model=args.model, base_url=base_url)
+
+    # Create generator and run
+    generator = IconGenerator(gemimg=gemimg, config=config)
+
+    try:
+        result = generator.generate(
+            prompt=args.prompt,
+            input_images=[Path(p) for p in args.input_images] if args.input_images else None,
+            light=Path(args.light) if args.light else None,
+            dark=Path(args.dark) if args.dark else None,
+            tinted=Path(args.tinted) if args.tinted else None,
+        )
+
+        print(f"Generated icons with {result.api_calls} API call(s)")
+        for key, paths in result.output_paths.items():
+            print(f"  {key}:")
+            for path in paths:
+                print(f"    - {path}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    """CLI for generating images with GemImg."""
+    # Check if first argument is 'icons' subcommand
+    if len(sys.argv) > 1 and sys.argv[1] == "icons":
+        # Icons subcommand
+        parser = argparse.ArgumentParser(
+            prog="gemimg icons",
+            description="Generate app icons for multiple platforms.",
+        )
+
+        parser.add_argument(
+            "prompt",
+            nargs="?",
+            default=None,
+            help="Text prompt for icon generation.",
+        )
+        parser.add_argument(
+            "-i",
+            "--input-images",
+            nargs="+",
+            default=[],
+            help="Input images (0=prompt only, 1=light, 2-3=variants, 4+=style refs).",
+        )
+        parser.add_argument(
+            "--light",
+            default=None,
+            help="Explicit light variant file.",
+        )
+        parser.add_argument(
+            "--dark",
+            default=None,
+            help="Explicit dark variant file.",
+        )
+        parser.add_argument(
+            "--tinted",
+            default=None,
+            help="Explicit tinted/monochrome variant file.",
+        )
+        parser.add_argument(
+            "-o",
+            "--output-dir",
+            default="icons",
+            help="Output directory for generated icons (default: icons/).",
+        )
+
+        # Icon type (mutually exclusive)
+        icon_type_group = parser.add_mutually_exclusive_group()
+        icon_type_group.add_argument(
+            "--app-icon",
+            action="store_true",
+            default=True,
+            help="Main launcher icon (default). Opaque background enforced.",
+        )
+        icon_type_group.add_argument(
+            "--menu-icon",
+            action="store_true",
+            help="In-app UI icons. Transparency preserved.",
+        )
+        icon_type_group.add_argument(
+            "--favicon",
+            action="store_true",
+            help="Website favicons only (ICO + small PNGs).",
+        )
+
+        # Platform selection
+        parser.add_argument(
+            "--preset",
+            default="all",
+            choices=["mobile", "desktop", "apple", "all"],
+            help="Platform preset (default: all).",
+        )
+        parser.add_argument(
+            "--platforms",
+            nargs="+",
+            choices=["ios", "macos", "android", "windows", "pwa"],
+            help="Specific platforms (overrides --preset).",
+        )
+
+        # Themed variants
+        parser.add_argument(
+            "--themed",
+            action="store_true",
+            help="Generate all 3 variants (light+dark+tinted) in single call.",
+        )
+
+        # Post-processing options
+        parser.add_argument(
+            "--no-shadow",
+            action="store_true",
+            help="Skip macOS shadow template.",
+        )
+        parser.add_argument(
+            "--no-safe-zone-check",
+            action="store_true",
+            help="Skip Android safe zone validation.",
+        )
+
+        add_common_args(parser)
+
+        args = parser.parse_args(sys.argv[2:])
+        icons_command(args)
+
+    else:
+        # Default generate command (backward compatible)
+        parser = argparse.ArgumentParser(
+            description="Generate images using the Gemini API."
+        )
+
+        parser.add_argument("prompt", help="The text prompt for image generation.")
+        parser.add_argument(
+            "-i",
+            "--input-images",
+            nargs="+",
+            help="Optional paths to input images.",
+            default=[],
+        )
+        parser.add_argument(
+            "-o",
+            "--output-file",
+            help="Optional output filename. Defaults to output.png, output-2.png, etc.",
+            default=None,
+        )
+        parser.add_argument(
+            "--aspect-ratio", default="1:1", help="Aspect ratio of the generated image."
+        )
+        parser.add_argument(
+            "--no-resize",
+            action="store_false",
+            dest="resize_inputs",
+            help="Do not resize input images.",
+        )
+        parser.add_argument(
+            "--output-dir", default="", help="Directory to save the generated images."
+        )
+        parser.add_argument(
+            "--temperature", type=float, default=1.0, help="Generation temperature."
+        )
+        parser.add_argument(
+            "--webp", action="store_true", help="Save as WEBP instead of PNG."
+        )
+        parser.add_argument("-n", type=int, default=1, help="Number of images to generate.")
+        parser.add_argument(
+            "--store-prompt",
+            action="store_true",
+            help="Store the prompt in the image metadata.",
+        )
+        parser.add_argument(
+            "--image-size",
+            default="2K",
+            help="Image size for the generation (Pro models only).",
+        )
+        parser.add_argument(
+            "--system-prompt",
+            default=None,
+            help="System prompt for the generation (Pro models only).",
+        )
+        parser.add_argument(
+            "--grid",
+            default=None,
+            help="Grid dimensions as ROWSxCOLS (e.g., 2x2). Pro models only.",
+        )
+        parser.add_argument(
+            "--grid-aspect-ratio",
+            default="1:1",
+            help="Aspect ratio for grid cells (default: 1:1).",
+        )
+        parser.add_argument(
+            "--grid-image-size",
+            default="2K",
+            help="Image size for grid generation (default: 2K).",
+        )
+        parser.add_argument(
+            "--save-grid-original",
+            action="store_true",
+            help="Save the original grid image before slicing.",
+        )
+        parser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            help="Force overwrite of existing files.",
+        )
+
+        add_common_args(parser)
+
+        args = parser.parse_args()
+        generate_command(args)
 
 
 if __name__ == "__main__":

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -7,21 +7,81 @@ from .gemimg import GemImg
 from .grid import Grid
 from .utils import save_image
 
+# Model names for help text
+MODELS = {
+    "flash": "gemini-2.5-flash-image",
+    "pro": "gemini-2.5-pro-image",
+    "gemini3-flash": "gemini-3.0-flash-image",
+    "gemini3-pro": "gemini-3.0-pro-image",
+}
+DEFAULT_MODEL = MODELS["flash"]
 
-def add_common_args(parser: argparse.ArgumentParser) -> None:
-    """Add common arguments shared between commands."""
-    parser.add_argument(
+
+def add_api_args(parser: argparse.ArgumentParser) -> None:
+    """Add API connection arguments."""
+    group = parser.add_argument_group(
+        "API Connection",
+        "Authentication and endpoint configuration."
+    )
+    group.add_argument(
         "--api-key",
         default=os.getenv("GEMINI_API_KEY"),
-        help="API key for the Gemini API. Defaults to the GEMINI_API_KEY environment variable.",
+        metavar="KEY",
+        help="Gemini API key. Defaults to GEMINI_API_KEY env var.",
     )
-    parser.add_argument(
-        "--model", default="gemini-2.5-flash-image", help="The model to use."
+    group.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        metavar="NAME",
+        help=f"Model to use (default: {DEFAULT_MODEL}). "
+             "Pro models support --image-size and --system-prompt. "
+             "Gemini 3 models support --google-search.",
     )
-    parser.add_argument(
+    group.add_argument(
         "--base-url",
         default=os.getenv("GOOGLE_GEMINI_BASE_URL"),
-        help="Alternative Gemini API endpoint for your organization.",
+        metavar="URL",
+        help="Alternative API endpoint (defaults to GOOGLE_GEMINI_BASE_URL env var).",
+    )
+
+
+def add_generation_args(parser: argparse.ArgumentParser, for_icons: bool = False) -> None:
+    """Add generation parameters shared between commands.
+
+    Args:
+        parser: The argument parser to add arguments to.
+        for_icons: If True, uses icon-appropriate defaults (1K size, 1:1 aspect).
+    """
+    group = parser.add_argument_group(
+        "Generation Options",
+        "Control image generation behavior. Some options require Pro or Gemini 3 models."
+    )
+    group.add_argument(
+        "--temperature",
+        type=float,
+        default=1.0,
+        metavar="FLOAT",
+        help="Creativity level 0.0-2.0 (default: 1.0). "
+             "Lower = more deterministic, higher = more varied.",
+    )
+    # image-size: icons default to 1K (smaller, many variants), general defaults to 2K
+    default_size = "1K" if for_icons else "2K"
+    group.add_argument(
+        "--image-size",
+        default=default_size,
+        choices=["1K", "2K", "4K"],
+        help=f"Output resolution (default: {default_size}). [Pro models only]",
+    )
+    group.add_argument(
+        "--system-prompt",
+        default=None,
+        metavar="TEXT",
+        help="Custom system instruction to guide generation style. [Pro models only]",
+    )
+    group.add_argument(
+        "--google-search",
+        action="store_true",
+        help="Enable Google Search grounding for real-time information. [Gemini 3 only]",
     )
 
 
@@ -211,134 +271,133 @@ The icons subcommand handles all platform-specific requirements:
   - macOS: ICNS format with optional drop shadow
   - Android: Adaptive icons with safe zone validation
   - Windows: Multi-size ICO file
-  - PWA: Manifest with regular and maskable icons""",
+  - PWA: Manifest with regular and maskable icons
+
+Model Capabilities:
+  Flash models  - Basic generation, up to 6 input images
+  Pro models    - --image-size, --system-prompt, up to 6 input images
+  Gemini 3      - --google-search, up to 14 input images""",
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 
-        parser.add_argument(
+        # Input/Output group
+        io_group = parser.add_argument_group(
+            "Input/Output",
+            "Source images and output destination."
+        )
+        io_group.add_argument(
             "prompt",
             nargs="?",
             default=None,
             help="Text description of the icon to generate (e.g., 'a minimalist coffee cup').",
         )
-        parser.add_argument(
+        io_group.add_argument(
             "-i",
             "--input-images",
             nargs="+",
             default=[],
-            help="""Input image(s) for processing or style reference:
-  1 image  → Used as light variant
-  2 images → light + dark variants
-  3 images → light + dark + tinted variants
-  4+ images → All used as style references for generation""",
-        )
-        parser.add_argument(
-            "--light",
-            default=None,
             metavar="FILE",
-            help="Explicit path to light mode icon variant.",
+            help="Input image(s): 1=light, 2=light+dark, 3=all variants, 4+=style refs.",
         )
-        parser.add_argument(
-            "--dark",
-            default=None,
-            metavar="FILE",
-            help="Explicit path to dark mode icon variant.",
-        )
-        parser.add_argument(
-            "--tinted",
-            default=None,
-            metavar="FILE",
-            help="Explicit path to tinted/monochrome variant (for Android themed icons).",
-        )
-        parser.add_argument(
+        io_group.add_argument(
             "-o",
             "--output-dir",
             default="icons",
             metavar="DIR",
-            help="Output directory for generated icons (default: icons/).",
+            help="Output directory (default: icons/).",
         )
 
-        # Icon type (mutually exclusive)
-        icon_type_group = parser.add_mutually_exclusive_group()
-        icon_type_group.add_argument(
+        # Explicit variant files group
+        variant_group = parser.add_argument_group(
+            "Explicit Variants",
+            "Provide pre-made icon variants (overrides --input-images interpretation)."
+        )
+        variant_group.add_argument(
+            "--light",
+            default=None,
+            metavar="FILE",
+            help="Light mode icon variant.",
+        )
+        variant_group.add_argument(
+            "--dark",
+            default=None,
+            metavar="FILE",
+            help="Dark mode icon variant.",
+        )
+        variant_group.add_argument(
+            "--tinted",
+            default=None,
+            metavar="FILE",
+            help="Tinted/monochrome variant (for Android themed icons).",
+        )
+
+        # Icon type group
+        type_group = parser.add_argument_group(
+            "Icon Type",
+            "What kind of icon to generate (mutually exclusive)."
+        )
+        icon_type_mutex = type_group.add_mutually_exclusive_group()
+        icon_type_mutex.add_argument(
             "--app-icon",
             action="store_true",
             default=True,
-            help="Main launcher icon (default). Opaque background enforced.",
+            help="Launcher icon with opaque background (default).",
         )
-        icon_type_group.add_argument(
+        icon_type_mutex.add_argument(
             "--menu-icon",
             action="store_true",
-            help="In-app UI icons. Transparency preserved.",
+            help="In-app UI icon with transparency preserved.",
         )
-        icon_type_group.add_argument(
+        icon_type_mutex.add_argument(
             "--favicon",
             action="store_true",
-            help="Website favicons only (ICO + small PNGs).",
+            help="Website favicon (ICO + small PNGs).",
         )
 
-        # Platform selection
-        parser.add_argument(
+        # Platform selection group
+        platform_group = parser.add_argument_group(
+            "Platform Selection",
+            "Choose target platforms. --platforms overrides --preset."
+        )
+        platform_group.add_argument(
             "--preset",
             default="all",
             choices=["mobile", "desktop", "apple", "all"],
-            help="Platform preset (default: all).",
+            help="Platform preset: mobile=iOS+Android, desktop=macOS+Windows, "
+                 "apple=iOS+macOS, all=everything (default).",
         )
-        parser.add_argument(
+        platform_group.add_argument(
             "--platforms",
             nargs="+",
             choices=["ios", "macos", "android", "windows", "pwa"],
-            help="Specific platforms (overrides --preset).",
+            metavar="PLATFORM",
+            help="Specific platforms to generate for.",
         )
 
-        # Themed variants
-        parser.add_argument(
+        # Icon processing group
+        processing_group = parser.add_argument_group(
+            "Icon Processing",
+            "Post-processing options for platform-specific requirements."
+        )
+        processing_group.add_argument(
             "--themed",
             action="store_true",
-            help="Generate all 3 variants (light+dark+tinted) in single call.",
+            help="Generate all 3 variants (light+dark+tinted) for themed icon support.",
         )
-
-        # Post-processing options
-        parser.add_argument(
+        processing_group.add_argument(
             "--no-shadow",
             action="store_true",
-            help="Skip macOS shadow template.",
+            help="Skip macOS drop shadow effect.",
         )
-        parser.add_argument(
+        processing_group.add_argument(
             "--no-safe-zone-check",
             action="store_true",
-            help="Skip Android safe zone validation.",
+            help="Skip Android adaptive icon safe zone validation.",
         )
 
-        # Generation options (Pro models only for some features)
-        parser.add_argument(
-            "--image-size",
-            default="1K",
-            choices=["1K", "2K", "4K"],
-            help="Generated icon resolution (Pro models only). Default: 1K. Higher = more detail.",
-        )
-        parser.add_argument(
-            "--system-prompt",
-            default=None,
-            metavar="TEXT",
-            help="Custom system prompt to override built-in icon prompts (Pro models only).",
-        )
-        parser.add_argument(
-            "--temperature",
-            type=float,
-            default=1.0,
-            metavar="FLOAT",
-            help="Generation randomness 0.0-2.0 (default: 1.0). Lower = more consistent output.",
-        )
-
-        # Gemini 3 specific options
-        parser.add_argument(
-            "--google-search",
-            action="store_true",
-            help="Enable Google Search grounding (Gemini 3 models only). Useful for current events/brands.",
-        )
-
-        add_common_args(parser)
+        # Shared generation args and API args
+        add_generation_args(parser, for_icons=True)
+        add_api_args(parser)
 
         args = parser.parse_args(sys.argv[2:])
         icons_command(args)
@@ -346,90 +405,127 @@ The icons subcommand handles all platform-specific requirements:
     else:
         # Default generate command (backward compatible)
         parser = argparse.ArgumentParser(
-            description="Generate images using the Gemini API."
+            prog="gemimg",
+            description="""Generate images using the Gemini API.
+
+Examples:
+  gemimg "a sunset over mountains"                    # Basic generation
+  gemimg "oil painting style" -i photo.jpg            # Transform image
+  gemimg "product photo" --aspect-ratio 16:9          # Custom aspect ratio
+  gemimg "logo design" -n 4 --temperature 1.5         # Multiple variations
+  gemimg "diagram" --grid 2x2                         # Generate 4-panel grid
+
+Model Capabilities:
+  Flash models  - Basic generation, up to 6 input images
+  Pro models    - --image-size, --system-prompt, --grid, up to 6 input images
+  Gemini 3      - --google-search, up to 14 input images""",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 
-        parser.add_argument("prompt", help="The text prompt for image generation.")
-        parser.add_argument(
+        # Input/Output group
+        io_group = parser.add_argument_group(
+            "Input/Output",
+            "Source content and output destination."
+        )
+        io_group.add_argument(
+            "prompt",
+            help="Text description for image generation.",
+        )
+        io_group.add_argument(
             "-i",
             "--input-images",
             nargs="+",
-            help="Optional paths to input images.",
             default=[],
+            metavar="FILE",
+            help="Input images for transformation or style reference.",
         )
-        parser.add_argument(
+        io_group.add_argument(
             "-o",
             "--output-file",
-            help="Optional output filename. Defaults to output.png, output-2.png, etc.",
             default=None,
+            metavar="FILE",
+            help="Output filename (default: output.png, output-2.png, ...).",
         )
-        parser.add_argument(
-            "--aspect-ratio", default="1:1", help="Aspect ratio of the generated image."
+        io_group.add_argument(
+            "--output-dir",
+            default="",
+            metavar="DIR",
+            help="Directory for output files.",
         )
-        parser.add_argument(
-            "--no-resize",
-            action="store_false",
-            dest="resize_inputs",
-            help="Do not resize input images.",
-        )
-        parser.add_argument(
-            "--output-dir", default="", help="Directory to save the generated images."
-        )
-        parser.add_argument(
-            "--temperature", type=float, default=1.0, help="Generation temperature."
-        )
-        parser.add_argument(
-            "--webp", action="store_true", help="Save as WEBP instead of PNG."
-        )
-        parser.add_argument("-n", type=int, default=1, help="Number of images to generate.")
-        parser.add_argument(
-            "--store-prompt",
-            action="store_true",
-            help="Store the prompt in the image metadata.",
-        )
-        parser.add_argument(
-            "--image-size",
-            default="2K",
-            help="Image size for the generation (Pro models only).",
-        )
-        parser.add_argument(
-            "--system-prompt",
-            default=None,
-            help="System prompt for the generation (Pro models only).",
-        )
-        parser.add_argument(
-            "--grid",
-            default=None,
-            help="Grid dimensions as ROWSxCOLS (e.g., 2x2). Pro models only.",
-        )
-        parser.add_argument(
-            "--google-search",
-            action="store_true",
-            help="Enable Google Search grounding for real-time data (Gemini 3 Pro only).",
-        )
-        parser.add_argument(
-            "--grid-aspect-ratio",
-            default="1:1",
-            help="Aspect ratio for grid cells (default: 1:1).",
-        )
-        parser.add_argument(
-            "--grid-image-size",
-            default="2K",
-            help="Image size for grid generation (default: 2K).",
-        )
-        parser.add_argument(
-            "--save-grid-original",
-            action="store_true",
-            help="Save the original grid image before slicing.",
-        )
-        parser.add_argument(
+        io_group.add_argument(
             "-f",
             "--force",
             action="store_true",
-            help="Force overwrite of existing files.",
+            help="Overwrite existing files without prompting.",
         )
 
-        add_common_args(parser)
+        # Image format group
+        format_group = parser.add_argument_group(
+            "Image Format",
+            "Control output image properties."
+        )
+        format_group.add_argument(
+            "--aspect-ratio",
+            default="1:1",
+            metavar="RATIO",
+            help="Output aspect ratio (default: 1:1). Examples: 16:9, 4:3, 3:4.",
+        )
+        format_group.add_argument(
+            "--webp",
+            action="store_true",
+            help="Save as WebP instead of PNG.",
+        )
+        format_group.add_argument(
+            "--no-resize",
+            action="store_false",
+            dest="resize_inputs",
+            help="Don't resize input images (may cause API errors for large images).",
+        )
+        format_group.add_argument(
+            "-n",
+            type=int,
+            default=1,
+            metavar="COUNT",
+            help="Number of images to generate (default: 1).",
+        )
+        format_group.add_argument(
+            "--store-prompt",
+            action="store_true",
+            help="Embed the prompt in output image metadata.",
+        )
+
+        # Grid generation group (Pro only)
+        grid_group = parser.add_argument_group(
+            "Grid Generation [Pro models only]",
+            "Generate multi-panel image grids."
+        )
+        grid_group.add_argument(
+            "--grid",
+            default=None,
+            metavar="RxC",
+            help="Grid dimensions as ROWSxCOLS (e.g., 2x2, 3x3).",
+        )
+        grid_group.add_argument(
+            "--grid-aspect-ratio",
+            default="1:1",
+            metavar="RATIO",
+            help="Aspect ratio for each grid cell (default: 1:1).",
+        )
+        grid_group.add_argument(
+            "--grid-image-size",
+            default="2K",
+            choices=["1K", "2K", "4K"],
+            help="Resolution for grid generation (default: 2K).",
+        )
+        grid_group.add_argument(
+            "--save-grid-original",
+            action="store_true",
+            help="Save the full grid image before slicing into cells.",
+        )
+
+        # Shared generation args and API args
+        add_generation_args(parser, for_icons=False)
+        add_api_args(parser)
 
         args = parser.parse_args()
         generate_command(args)

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -173,6 +173,7 @@ def icons_command(args: argparse.Namespace) -> None:
             light=Path(args.light) if args.light else None,
             dark=Path(args.dark) if args.dark else None,
             tinted=Path(args.tinted) if args.tinted else None,
+            google_search=args.google_search,
         )
 
         print(f"Generated icons with {result.api_calls} API call(s)")
@@ -281,6 +282,13 @@ def main():
             "--no-safe-zone-check",
             action="store_true",
             help="Skip Android safe zone validation.",
+        )
+
+        # Gemini 3 Pro options
+        parser.add_argument(
+            "--google-search",
+            action="store_true",
+            help="Enable Google Search grounding for real-time data (Gemini 3 Pro only).",
         )
 
         add_common_args(parser)

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -334,7 +334,7 @@ Model Capabilities:
         # Explicit variant files group
         variant_group = parser.add_argument_group(
             "Explicit Variants",
-            "Provide pre-made icon variants (overrides --input-images interpretation)."
+            "Provide pre-made icon variants (skips AI generation for that variant)."
         )
         variant_group.add_argument(
             "--light",

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -147,7 +147,7 @@ def icons_command(args: argparse.Namespace) -> None:
     else:
         icon_type = IconType.APP_ICON
 
-    # Create config
+    # Create config with all overridable parameters
     config = IconGeneratorConfig(
         icon_type=icon_type,
         platforms=platforms,
@@ -155,6 +155,9 @@ def icons_command(args: argparse.Namespace) -> None:
         macos_shadow=not args.no_shadow,
         validate_safe_zone=not args.no_safe_zone_check,
         output_dir=Path(args.output_dir),
+        image_size=args.image_size,
+        temperature=args.temperature,
+        system_prompt=args.system_prompt,
     )
 
     # Create GemImg instance if needed
@@ -194,41 +197,64 @@ def main():
         # Icons subcommand
         parser = argparse.ArgumentParser(
             prog="gemimg icons",
-            description="Generate app icons for multiple platforms.",
+            description="""Generate production-ready app icons for iOS, macOS, Android, Windows, and PWA.
+
+Examples:
+  gemimg icons "a friendly robot mascot"              # Generate from prompt
+  gemimg icons -i logo.png                            # Process existing image
+  gemimg icons "gaming app" --platforms ios android   # Specific platforms
+  gemimg icons -i icon.png --themed                   # Generate all 3 variants
+  gemimg icons "tech startup" --image-size 2K         # Higher resolution
+
+The icons subcommand handles all platform-specific requirements:
+  - iOS: App Store sizes (1024px down to 20px)
+  - macOS: ICNS format with optional drop shadow
+  - Android: Adaptive icons with safe zone validation
+  - Windows: Multi-size ICO file
+  - PWA: Manifest with regular and maskable icons""",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 
         parser.add_argument(
             "prompt",
             nargs="?",
             default=None,
-            help="Text prompt for icon generation.",
+            help="Text description of the icon to generate (e.g., 'a minimalist coffee cup').",
         )
         parser.add_argument(
             "-i",
             "--input-images",
             nargs="+",
             default=[],
-            help="Input images (0=prompt only, 1=light, 2-3=variants, 4+=style refs).",
+            help="""Input image(s) for processing or style reference:
+  1 image  → Used as light variant
+  2 images → light + dark variants
+  3 images → light + dark + tinted variants
+  4+ images → All used as style references for generation""",
         )
         parser.add_argument(
             "--light",
             default=None,
-            help="Explicit light variant file.",
+            metavar="FILE",
+            help="Explicit path to light mode icon variant.",
         )
         parser.add_argument(
             "--dark",
             default=None,
-            help="Explicit dark variant file.",
+            metavar="FILE",
+            help="Explicit path to dark mode icon variant.",
         )
         parser.add_argument(
             "--tinted",
             default=None,
-            help="Explicit tinted/monochrome variant file.",
+            metavar="FILE",
+            help="Explicit path to tinted/monochrome variant (for Android themed icons).",
         )
         parser.add_argument(
             "-o",
             "--output-dir",
             default="icons",
+            metavar="DIR",
             help="Output directory for generated icons (default: icons/).",
         )
 
@@ -284,11 +310,32 @@ def main():
             help="Skip Android safe zone validation.",
         )
 
-        # Gemini 3 Pro options
+        # Generation options (Pro models only for some features)
+        parser.add_argument(
+            "--image-size",
+            default="1K",
+            choices=["1K", "2K", "4K"],
+            help="Generated icon resolution (Pro models only). Default: 1K. Higher = more detail.",
+        )
+        parser.add_argument(
+            "--system-prompt",
+            default=None,
+            metavar="TEXT",
+            help="Custom system prompt to override built-in icon prompts (Pro models only).",
+        )
+        parser.add_argument(
+            "--temperature",
+            type=float,
+            default=1.0,
+            metavar="FLOAT",
+            help="Generation randomness 0.0-2.0 (default: 1.0). Lower = more consistent output.",
+        )
+
+        # Gemini 3 specific options
         parser.add_argument(
             "--google-search",
             action="store_true",
-            help="Enable Google Search grounding for real-time data (Gemini 3 Pro only).",
+            help="Enable Google Search grounding (Gemini 3 models only). Useful for current events/brands.",
         )
 
         add_common_args(parser)

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -320,11 +320,8 @@ Model Capabilities:
             type=existing_file,
             default=[],
             metavar="FILE",
-            help="Input image file(s). Interpretation by count: "
-                 "1 file → light variant; "
-                 "2 files → light, dark; "
-                 "3 files → light, dark, tinted; "
-                 "4+ files → first 3 as variants, rest as style references.",
+            help="Style reference images for AI generation. "
+                 "Use --light/--dark/--tinted to provide pre-made variants.",
         )
         io_group.add_argument(
             "-o",
@@ -468,7 +465,7 @@ Model Capabilities:
             type=existing_file,
             default=[],
             metavar="FILE",
-            help="Input images for transformation or style reference.",
+            help="Style reference images for AI generation context.",
         )
         io_group.add_argument(
             "-o",

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -80,6 +80,11 @@ def main():
         help="Grid dimensions as ROWSxCOLS (e.g., 2x2). Pro models only.",
     )
     parser.add_argument(
+        "--google-search",
+        action="store_true",
+        help="Enable Google Search grounding for real-time data (Gemini 3 Pro only).",
+    )
+    parser.add_argument(
         "--grid-aspect-ratio",
         default="1:1",
         help="Aspect ratio for grid cells (default: 1:1).",
@@ -146,6 +151,7 @@ def main():
         image_size=args.image_size,
         system_prompt=args.system_prompt,
         grid=grid,
+        google_search=args.google_search,
     )
 
     if result and result.images:

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -7,6 +7,28 @@ from .gemimg import GemImg
 from .grid import Grid
 from .utils import save_image
 
+
+def existing_file(path: str) -> str:
+    """Argparse type validator that ensures file exists."""
+    if not Path(path).exists():
+        raise argparse.ArgumentTypeError(f"File not found: {path}")
+    if not Path(path).is_file():
+        raise argparse.ArgumentTypeError(f"Not a file: {path}")
+    return path
+
+
+def temperature_range(value: str) -> float:
+    """Argparse type validator for temperature (0.0-2.0)."""
+    try:
+        temp = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid temperature: {value}")
+    if not 0.0 <= temp <= 2.0:
+        raise argparse.ArgumentTypeError(
+            f"Temperature must be between 0.0 and 2.0, got {temp}"
+        )
+    return temp
+
 # Model names for help text
 MODELS = {
     "flash": "gemini-2.5-flash-image",
@@ -50,7 +72,7 @@ def add_generation_args(parser: argparse.ArgumentParser, for_icons: bool = False
 
     Args:
         parser: The argument parser to add arguments to.
-        for_icons: If True, uses icon-appropriate defaults (1K size, 1:1 aspect).
+        for_icons: If True, used for icons subcommand context (currently unused).
     """
     group = parser.add_argument_group(
         "Generation Options",
@@ -58,14 +80,14 @@ def add_generation_args(parser: argparse.ArgumentParser, for_icons: bool = False
     )
     group.add_argument(
         "--temperature",
-        type=float,
+        type=temperature_range,
         default=1.0,
         metavar="FLOAT",
         help="Creativity level 0.0-2.0 (default: 1.0). "
              "Lower = more deterministic, higher = more varied.",
     )
-    # image-size: icons default to 1K (smaller, many variants), general defaults to 2K
-    default_size = "1K" if for_icons else "2K"
+    # image-size: both icons and general default to 2K for future-proofing
+    default_size = "2K"
     group.add_argument(
         "--image-size",
         default=default_size,
@@ -295,9 +317,14 @@ Model Capabilities:
             "-i",
             "--input-images",
             nargs="+",
+            type=existing_file,
             default=[],
             metavar="FILE",
-            help="Input image(s): 1=light, 2=light+dark, 3=all variants, 4+=style refs.",
+            help="Input image file(s). Interpretation by count: "
+                 "1 file → light variant; "
+                 "2 files → light, dark; "
+                 "3 files → light, dark, tinted; "
+                 "4+ files → first 3 as variants, rest as style references.",
         )
         io_group.add_argument(
             "-o",
@@ -314,18 +341,21 @@ Model Capabilities:
         )
         variant_group.add_argument(
             "--light",
+            type=existing_file,
             default=None,
             metavar="FILE",
             help="Light mode icon variant.",
         )
         variant_group.add_argument(
             "--dark",
+            type=existing_file,
             default=None,
             metavar="FILE",
             help="Dark mode icon variant.",
         )
         variant_group.add_argument(
             "--tinted",
+            type=existing_file,
             default=None,
             metavar="FILE",
             help="Tinted/monochrome variant (for Android themed icons).",
@@ -435,6 +465,7 @@ Model Capabilities:
             "-i",
             "--input-images",
             nargs="+",
+            type=existing_file,
             default=[],
             metavar="FILE",
             help="Input images for transformation or style reference.",

--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -137,21 +137,48 @@ class GemImg:
             response = self.client.post(
                 api_url, json=query_params, headers=headers, timeout=180
             )
+            response.raise_for_status()
         except httpx.TimeoutException:
-            logger.error("Request Timeout")
+            logger.error(
+                "Request timed out after 180 seconds. "
+                "The API may be experiencing high load. Please try again."
+            )
             return None
         except httpx.HTTPStatusError as e:
-            logger.error(f"HTTP error occurred: {e}")
+            status_code = e.response.status_code
+            if status_code == 401:
+                logger.error("Authentication failed. Check your GEMINI_API_KEY.")
+            elif status_code == 403:
+                logger.error("Access forbidden. Check API quota or region restrictions.")
+            elif status_code == 429:
+                logger.error("Rate limit exceeded. Please wait before retrying.")
+            elif status_code >= 500:
+                logger.error(f"Server error ({status_code}). Please try again later.")
+            else:
+                logger.error(f"HTTP error {status_code}: {e.response.text[:200]}")
             return None
 
-        response_data = response.json()
+        try:
+            response_data = response.json()
+        except ValueError as e:
+            logger.error(f"API returned invalid JSON response: {e}")
+            return None
+
         if err := response_data.get("error"):
-            logger.error(f"API Response Error: {err['code']} — {err['message']}")
+            logger.error(f"API Response Error: {err.get('code', 'unknown')} — {err.get('message', 'unknown error')}")
             return None
 
+        # Defensive parsing with clear error messages
+        if "usageMetadata" not in response_data:
+            logger.error("API response missing 'usageMetadata' field.")
+            return None
         usage_metadata = response_data["usageMetadata"]
-        # Check for prohibited content
+
+        if "candidates" not in response_data or not response_data["candidates"]:
+            logger.error("API response missing 'candidates' field.")
+            return None
         candidates = response_data["candidates"][0]
+
         finish_reason = candidates.get("finishReason")
         if finish_reason in ["PROHIBITED_CONTENT", "NO_IMAGE"]:
             logger.error(f"Image was not generated due to {finish_reason}.")
@@ -161,7 +188,7 @@ class GemImg:
             logger.error("No image is present in the response.")
             return None
 
-        response_parts = candidates["content"]["parts"]
+        response_parts = candidates["content"].get("parts", [])
 
         output_images = [
             b64_to_img(part["inlineData"]["data"])
@@ -213,16 +240,36 @@ class GemImg:
             subimage_paths=output_subimage_paths,
         )
 
-    def _generate_multiple(self, n: int, **kwargs) -> "ImageGen":
-        """Helper to generate multiple images by accumulating results."""
-        n = kwargs.pop("n")
+    def _generate_multiple(self, n: int, **kwargs) -> Optional["ImageGen"]:
+        """Helper to generate multiple images by accumulating results.
+
+        Handles partial failures gracefully - if some API calls fail,
+        returns successful results. Only returns None if all calls fail.
+        """
+        # Remove 'n' from kwargs if present to avoid duplication
+        kwargs.pop("n", None)
+
         result = None
-        for _ in range(n):
+        failed_count = 0
+
+        for i in range(n):
             gen_result = self.generate(n=1, **kwargs)
+            if gen_result is None:
+                failed_count += 1
+                logger.warning(f"Image generation {i + 1}/{n} failed.")
+                continue
+
             if result is None:
                 result = gen_result
             else:
                 result += gen_result
+
+        if failed_count > 0 and result is not None:
+            logger.warning(
+                f"Generated {n - failed_count}/{n} images. "
+                f"{failed_count} generation(s) failed."
+            )
+
         return result
 
 

--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -126,6 +126,18 @@ class GemImg:
                 query_params["system_instruction"] = {
                     "parts": [{"text": system_prompt.strip()}]
                 }
+        else:
+            # Warn about Pro-only options that will be ignored
+            if system_prompt:
+                logger.warning(
+                    f"system_prompt is ignored for {self.model}. "
+                    "Use a Pro model (e.g., gemini-3-pro-image-preview) for custom prompts."
+                )
+            if image_size and image_size != "2K":
+                logger.warning(
+                    f"image_size '{image_size}' is ignored for {self.model}. "
+                    "Use a Pro model for 1K/4K resolution control."
+                )
 
         # Add Google Search grounding for Gemini 3
         if google_search:

--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -41,6 +41,11 @@ class GemImg:
         """Check if the model is a pro variant."""
         return "-pro" in self.model
 
+    @property
+    def is_gemini3(self) -> bool:
+        """Check if the model is a Gemini 3 variant."""
+        return "gemini-3" in self.model
+
     def generate(
         self,
         prompt: Optional[str] = None,
@@ -56,9 +61,14 @@ class GemImg:
         image_size: str = "2K",
         system_prompt: Optional[str] = None,
         grid: Optional[Grid] = None,
+        google_search: bool = False,
     ) -> Optional["ImageGen"]:
         if not prompt and not imgs:
             raise ValueError("Either 'prompt' or 'imgs' must be provided")
+
+        # Validate Google Search is only used with Gemini 3
+        if google_search and not self.is_gemini3:
+            raise ValueError("Google Search grounding requires Gemini 3 Pro Image")
 
         # If grid is provided, use its aspect_ratio and image_size
         if grid is not None:
@@ -82,6 +92,13 @@ class GemImg:
             # Ensure imgs is a list
             if isinstance(imgs, (str, Image.Image)):
                 imgs = [imgs]
+
+            # Validate input image count
+            max_images = 14 if self.is_gemini3 else 6
+            if len(imgs) > max_images:
+                raise ValueError(
+                    f"Maximum {max_images} input images for {self.model}"
+                )
 
             img_b64_strings = [img_to_b64(img, resize_inputs) for img in imgs]
             parts.extend([img_b64_part(b64_str) for b64_str in img_b64_strings])
@@ -108,6 +125,10 @@ class GemImg:
                 query_params["system_instruction"] = {
                     "parts": [{"text": system_prompt.strip()}]
                 }
+
+        # Add Google Search grounding for Gemini 3
+        if google_search:
+            query_params["tools"] = [{"googleSearch": {}}]
 
         headers = {"Content-Type": "application/json", "x-goog-api-key": self.api_key}
         api_url = f"{self.base_url}/v1beta/models/{self.model}:generateContent"

--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -68,7 +68,7 @@ class GemImg:
 
         # Validate Google Search is only used with Gemini 3
         if google_search and not self.is_gemini3:
-            raise ValueError("Google Search grounding requires Gemini 3 Pro Image")
+            raise ValueError("Google Search grounding requires a Gemini 3 model")
 
         # If grid is provided, use its aspect_ratio and image_size
         if grid is not None:

--- a/gemimg/gemimg.py
+++ b/gemimg/gemimg.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -160,7 +161,7 @@ class GemImg:
 
         try:
             response_data = response.json()
-        except ValueError as e:
+        except json.JSONDecodeError as e:
             logger.error(f"API returned invalid JSON response: {e}")
             return None
 

--- a/gemimg/icons/__init__.py
+++ b/gemimg/icons/__init__.py
@@ -1,6 +1,6 @@
 """App icon generation module for gemimg."""
 
-from .constants import Platform, Preset, IconSpec, IconType, PRESET_PLATFORMS
+from .constants import Platform, Preset, IconSpec, IconType, Variant, PRESET_PLATFORMS
 from .generator import IconGenerator, IconVariants, IconGenerationResult, IconGeneratorConfig
 from .platforms import (
     PlatformProcessor,
@@ -16,6 +16,7 @@ __all__ = [
     "Preset",
     "IconSpec",
     "IconType",
+    "Variant",
     "PRESET_PLATFORMS",
     "IconGenerator",
     "IconGeneratorConfig",

--- a/gemimg/icons/__init__.py
+++ b/gemimg/icons/__init__.py
@@ -1,0 +1,30 @@
+"""App icon generation module for gemimg."""
+
+from .constants import Platform, Preset, IconSpec, IconType, PRESET_PLATFORMS
+from .generator import IconGenerator, IconVariants, IconGenerationResult, IconGeneratorConfig
+from .platforms import (
+    PlatformProcessor,
+    IOSProcessor,
+    MacOSProcessor,
+    AndroidProcessor,
+    WindowsProcessor,
+    PWAProcessor,
+)
+
+__all__ = [
+    "Platform",
+    "Preset",
+    "IconSpec",
+    "IconType",
+    "PRESET_PLATFORMS",
+    "IconGenerator",
+    "IconGeneratorConfig",
+    "IconVariants",
+    "IconGenerationResult",
+    "PlatformProcessor",
+    "IOSProcessor",
+    "MacOSProcessor",
+    "AndroidProcessor",
+    "WindowsProcessor",
+    "PWAProcessor",
+]

--- a/gemimg/icons/constants.py
+++ b/gemimg/icons/constants.py
@@ -1,0 +1,178 @@
+"""Constants and types for app icon generation."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Tuple
+
+
+class Platform(Enum):
+    """Supported platforms for icon generation."""
+
+    IOS = "ios"
+    MACOS = "macos"
+    ANDROID = "android"
+    WINDOWS = "windows"
+    PWA = "pwa"
+
+
+class Preset(Enum):
+    """Preset platform groups."""
+
+    MOBILE = "mobile"  # iOS + Android
+    DESKTOP = "desktop"  # macOS + Windows
+    APPLE = "apple"  # iOS + macOS
+    ALL = "all"  # All platforms
+
+
+class IconType(Enum):
+    """Types of icons with different requirements."""
+
+    APP_ICON = "app-icon"  # Launcher icon, opaque background
+    MENU_ICON = "menu-icon"  # In-app icons, transparency allowed
+    FAVICON = "favicon"  # Website favicons
+
+
+PRESET_PLATFORMS: Dict[Preset, List[Platform]] = {
+    Preset.MOBILE: [Platform.IOS, Platform.ANDROID],
+    Preset.DESKTOP: [Platform.MACOS, Platform.WINDOWS],
+    Preset.APPLE: [Platform.IOS, Platform.MACOS],
+    Preset.ALL: [Platform.IOS, Platform.MACOS, Platform.ANDROID, Platform.WINDOWS, Platform.PWA],
+}
+
+
+@dataclass
+class IconSpec:
+    """Specification for a single icon size."""
+
+    width: int
+    height: int
+    scale: int = 1
+    purpose: str = "any"  # For PWA: "any", "maskable"
+    filename_suffix: str = ""
+
+    @property
+    def size(self) -> Tuple[int, int]:
+        """Return the (width, height) tuple."""
+        return (self.width, self.height)
+
+    @property
+    def scaled_size(self) -> Tuple[int, int]:
+        """Return the scaled (width, height) tuple."""
+        return (self.width * self.scale, self.height * self.scale)
+
+
+# iOS icon sizes (App Store requires 1024x1024 master)
+IOS_ICON_SPECS: List[IconSpec] = [
+    IconSpec(1024, 1024, 1, filename_suffix="1024"),
+    IconSpec(180, 180, 1, filename_suffix="180"),  # iPhone @3x
+    IconSpec(167, 167, 1, filename_suffix="167"),  # iPad Pro @2x
+    IconSpec(152, 152, 1, filename_suffix="152"),  # iPad @2x
+    IconSpec(120, 120, 1, filename_suffix="120"),  # iPhone @2x
+    IconSpec(87, 87, 1, filename_suffix="87"),  # Spotlight @3x
+    IconSpec(80, 80, 1, filename_suffix="80"),  # Spotlight @2x
+    IconSpec(76, 76, 1, filename_suffix="76"),  # iPad @1x
+    IconSpec(60, 60, 1, filename_suffix="60"),  # iPhone @1x
+    IconSpec(58, 58, 1, filename_suffix="58"),  # Settings @2x
+    IconSpec(40, 40, 1, filename_suffix="40"),  # Spotlight @1x
+    IconSpec(29, 29, 1, filename_suffix="29"),  # Settings @1x
+    IconSpec(20, 20, 1, filename_suffix="20"),  # Notifications @1x
+]
+
+# macOS icon sizes (with @2x variants)
+MACOS_ICON_SPECS: List[IconSpec] = [
+    IconSpec(512, 512, 2, filename_suffix="512@2x"),  # 1024x1024
+    IconSpec(512, 512, 1, filename_suffix="512"),
+    IconSpec(256, 256, 2, filename_suffix="256@2x"),  # 512x512
+    IconSpec(256, 256, 1, filename_suffix="256"),
+    IconSpec(128, 128, 2, filename_suffix="128@2x"),  # 256x256
+    IconSpec(128, 128, 1, filename_suffix="128"),
+    IconSpec(32, 32, 2, filename_suffix="32@2x"),  # 64x64
+    IconSpec(32, 32, 1, filename_suffix="32"),
+    IconSpec(16, 16, 2, filename_suffix="16@2x"),  # 32x32
+    IconSpec(16, 16, 1, filename_suffix="16"),
+]
+
+# Android icon sizes (adaptive icons use 512x512 master)
+ANDROID_ICON_SPECS: List[IconSpec] = [
+    IconSpec(512, 512, 1, filename_suffix="512"),  # Play Store
+    IconSpec(192, 192, 1, filename_suffix="xxxhdpi"),
+    IconSpec(144, 144, 1, filename_suffix="xxhdpi"),
+    IconSpec(96, 96, 1, filename_suffix="xhdpi"),
+    IconSpec(72, 72, 1, filename_suffix="hdpi"),
+    IconSpec(48, 48, 1, filename_suffix="mdpi"),
+]
+
+# Windows ICO sizes (multi-size ICO file)
+WINDOWS_ICO_SIZES: List[Tuple[int, int]] = [
+    (256, 256),
+    (128, 128),
+    (64, 64),
+    (48, 48),
+    (32, 32),
+    (16, 16),
+]
+
+# PWA icon sizes
+PWA_ICON_SPECS: List[IconSpec] = [
+    IconSpec(512, 512, 1, purpose="any", filename_suffix="512"),
+    IconSpec(512, 512, 1, purpose="maskable", filename_suffix="512-maskable"),
+    IconSpec(192, 192, 1, purpose="any", filename_suffix="192"),
+    IconSpec(192, 192, 1, purpose="maskable", filename_suffix="192-maskable"),
+    IconSpec(144, 144, 1, purpose="any", filename_suffix="144"),
+    IconSpec(96, 96, 1, purpose="any", filename_suffix="96"),
+    IconSpec(72, 72, 1, purpose="any", filename_suffix="72"),
+    IconSpec(48, 48, 1, purpose="any", filename_suffix="48"),
+]
+
+
+# AI prompt templates
+APP_ICON_PROMPT = """Generate an app icon with these MANDATORY requirements:
+- MUST have a solid, opaque background color (no transparency)
+- Background must completely fill the square canvas
+- No semi-transparent or alpha channel elements
+- sRGB color space
+- Simple, bold design readable at 60x60px
+- Centered composition with clear focal point
+- No elements touching edges (platforms apply corner masks)
+
+Icon subject: {user_prompt}"""
+
+MENU_ICON_PROMPT = """Generate a UI icon with these requirements:
+- Transparent background preferred
+- Simple, recognizable silhouette
+- Works at 24x24px to 48x48px
+- Monochrome-friendly design
+
+Icon subject: {user_prompt}"""
+
+THEMED_ICON_PROMPT = """Generate THREE distinct app icon variants for the following concept:
+
+{base_prompt}
+
+OUTPUT REQUIREMENTS (3 images):
+
+IMAGE 1 - LIGHT MODE:
+- Opaque solid background (no transparency)
+- Designed for light backgrounds
+- sRGB color space, 1024x1024
+
+IMAGE 2 - DARK MODE:
+- Opaque solid background, dark/rich colors
+- Optimized for dark backgrounds
+- Same brand identity, adjusted for dark theme visibility
+- sRGB color space, 1024x1024
+
+IMAGE 3 - TINTED/MONOCHROME:
+- Solid silhouette shape only
+- Clean edges, simple recognizable form
+- No internal details, just the outline/shape
+- Works as Android themed icon (system will colorize)
+- 1024x1024
+
+All three icons must be visually consistent and recognizable as the same brand."""
+
+# Android safe zone percentage (66% of total icon area)
+ANDROID_SAFE_ZONE_PERCENT = 0.66
+
+# PWA maskable icon padding (10% on each side)
+PWA_MASKABLE_PADDING_PERCENT = 0.10

--- a/gemimg/icons/constants.py
+++ b/gemimg/icons/constants.py
@@ -31,6 +31,24 @@ class IconType(Enum):
     MENU_ICON = "menu-icon"  # In-app icons, transparency allowed
     FAVICON = "favicon"  # Website favicons
 
+    @property
+    def allows_transparency(self) -> bool:
+        """Check if this icon type allows transparent backgrounds."""
+        return self != IconType.APP_ICON
+
+    @property
+    def requires_opaque_background(self) -> bool:
+        """Check if this icon type requires an opaque background."""
+        return self == IconType.APP_ICON
+
+
+class Variant(Enum):
+    """Icon theme variants for themed icon support."""
+
+    LIGHT = "light"
+    DARK = "dark"
+    TINTED = "tinted"
+
 
 PRESET_PLATFORMS: Dict[Preset, List[Platform]] = {
     Preset.MOBILE: [Platform.IOS, Platform.ANDROID],
@@ -38,6 +56,17 @@ PRESET_PLATFORMS: Dict[Preset, List[Platform]] = {
     Preset.APPLE: [Platform.IOS, Platform.MACOS],
     Preset.ALL: [Platform.IOS, Platform.MACOS, Platform.ANDROID, Platform.WINDOWS, Platform.PWA],
 }
+
+# Validate that PRESET_PLATFORMS[Preset.ALL] contains all Platform values
+# This check runs at module import time to catch configuration errors early
+_all_platforms = set(PRESET_PLATFORMS[Preset.ALL])
+_defined_platforms = set(Platform)
+if _all_platforms != _defined_platforms:
+    _missing = _defined_platforms - _all_platforms
+    raise ValueError(
+        f"PRESET_PLATFORMS[Preset.ALL] is missing platforms: {_missing}. "
+        "All Platform enum values must be included in the ALL preset."
+    )
 
 
 @dataclass

--- a/gemimg/icons/generator.py
+++ b/gemimg/icons/generator.py
@@ -22,6 +22,29 @@ from .platforms import get_processor
 logger = logging.getLogger(__name__)
 
 
+def _load_image(path: Path) -> Image.Image:
+    """Load image using context manager and return a copy to release file handle.
+
+    This follows RAII pattern - the file is opened, copied, and closed immediately.
+    The returned image is independent of the file handle.
+
+    Args:
+        path: Path to the image file
+
+    Returns:
+        A copy of the loaded image
+
+    Raises:
+        FileNotFoundError: If the image file does not exist
+        PIL.UnidentifiedImageError: If the file is not a valid image
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Image file not found: {path}")
+
+    with Image.open(path) as img:
+        return img.copy()
+
+
 @dataclass
 class IconVariants:
     """Container for all icon variants."""
@@ -29,6 +52,14 @@ class IconVariants:
     light: Optional[Image.Image] = None
     dark: Optional[Image.Image] = None
     tinted: Optional[Image.Image] = None
+
+    def has_any_variant(self) -> bool:
+        """Check if at least one variant is present."""
+        return any([self.light, self.dark, self.tinted])
+
+    def count(self) -> int:
+        """Return the number of non-None variants."""
+        return sum(1 for v in [self.light, self.dark, self.tinted] if v is not None)
 
 
 @dataclass
@@ -38,6 +69,11 @@ class IconGenerationResult:
     variants: IconVariants
     output_paths: Dict[str, List[Path]] = field(default_factory=dict)
     api_calls: int = 0
+
+    def __post_init__(self):
+        """Validate result fields."""
+        if self.api_calls < 0:
+            raise ValueError("api_calls cannot be negative")
 
 
 @dataclass
@@ -50,6 +86,11 @@ class IconGeneratorConfig:
     macos_shadow: bool = True
     validate_safe_zone: bool = True
     output_dir: Path = field(default_factory=lambda: Path("icons"))
+
+    def __post_init__(self):
+        """Validate configuration fields."""
+        if not self.platforms:
+            raise ValueError("At least one platform must be specified")
 
 
 class IconGenerator:
@@ -117,29 +158,30 @@ class IconGenerator:
         input_images = input_images or []
 
         # 1. Resolve explicit variant files (highest priority)
+        # Using _load_image() for RAII pattern - files are closed after copying
         variants = IconVariants(
-            light=Image.open(light) if light else None,
-            dark=Image.open(dark) if dark else None,
-            tinted=Image.open(tinted) if tinted else None,
+            light=_load_image(light) if light else None,
+            dark=_load_image(dark) if dark else None,
+            tinted=_load_image(tinted) if tinted else None,
         )
 
         # 2. Handle input images based on count
         if len(input_images) == 1 and not variants.light:
             # Single input = light variant (unless used as reference)
-            variants.light = Image.open(input_images[0])
+            variants.light = _load_image(input_images[0])
 
         elif len(input_images) == 2 and not (variants.dark or variants.tinted):
             # Two inputs = light + dark
             if not variants.light:
-                variants.light = Image.open(input_images[0])
-            variants.dark = Image.open(input_images[1])
+                variants.light = _load_image(input_images[0])
+            variants.dark = _load_image(input_images[1])
 
         elif len(input_images) == 3 and not (variants.dark or variants.tinted):
             # Three inputs = light + dark + tinted
             if not variants.light:
-                variants.light = Image.open(input_images[0])
-            variants.dark = Image.open(input_images[1])
-            variants.tinted = Image.open(input_images[2])
+                variants.light = _load_image(input_images[0])
+            variants.dark = _load_image(input_images[1])
+            variants.tinted = _load_image(input_images[2])
 
         # 3. Determine what needs to be generated
         needs_light = variants.light is None
@@ -149,9 +191,9 @@ class IconGenerator:
         # 4. Reference images for style consistency (4+ inputs, or inputs not used as variants)
         reference_images: List[Image.Image] = []
         if len(input_images) >= 4:
-            reference_images = [Image.open(p) for p in input_images]
+            reference_images = [_load_image(p) for p in input_images]
         elif len(input_images) > 0 and not needs_light:
-            reference_images = [Image.open(p) for p in input_images]
+            reference_images = [_load_image(p) for p in input_images]
 
         # 5. Generate missing variants (single API call)
         if needs_light or needs_dark or needs_tinted:

--- a/gemimg/icons/generator.py
+++ b/gemimg/icons/generator.py
@@ -78,7 +78,13 @@ class IconGenerationResult:
 
 @dataclass
 class IconGeneratorConfig:
-    """Configuration for icon generation."""
+    """Configuration for icon generation.
+
+    All generation parameters can be overridden from defaults:
+    - image_size: Resolution of generated icons (1K, 2K, 4K)
+    - temperature: Generation randomness (0.0-2.0)
+    - system_prompt: Custom prompt to override built-in icon prompts
+    """
 
     icon_type: IconType = IconType.APP_ICON
     platforms: Set[Platform] = field(default_factory=lambda: set(PRESET_PLATFORMS[Preset.ALL]))
@@ -86,11 +92,19 @@ class IconGeneratorConfig:
     macos_shadow: bool = True
     validate_safe_zone: bool = True
     output_dir: Path = field(default_factory=lambda: Path("icons"))
+    # Generation parameters (overridable)
+    image_size: str = "1K"
+    temperature: float = 1.0
+    system_prompt: Optional[str] = None
 
     def __post_init__(self):
         """Validate configuration fields."""
         if not self.platforms:
             raise ValueError("At least one platform must be specified")
+        if self.image_size not in ("1K", "2K", "4K"):
+            raise ValueError(f"image_size must be '1K', '2K', or '4K', got '{self.image_size}'")
+        if not 0.0 <= self.temperature <= 2.0:
+            raise ValueError(f"temperature must be between 0.0 and 2.0, got {self.temperature}")
 
 
 class IconGenerator:
@@ -208,12 +222,16 @@ class IconGenerator:
                 icon_type, prompt, needs_light, needs_dark, needs_tinted
             )
 
+            # Use system_prompt override if provided, otherwise use built prompt
+            final_prompt = self.config.system_prompt or gen_prompt
+
             result = self.gemimg.generate(
-                prompt=gen_prompt,
+                prompt=final_prompt,
                 imgs=reference_images if reference_images else None,
                 n=n_outputs,
-                aspect_ratio="1:1",
-                image_size="1K",
+                aspect_ratio="1:1",  # Icons are always square
+                image_size=self.config.image_size,
+                temperature=self.config.temperature,
                 save=False,
                 google_search=google_search,
             )

--- a/gemimg/icons/generator.py
+++ b/gemimg/icons/generator.py
@@ -179,35 +179,16 @@ class IconGenerator:
             tinted=_load_image(tinted) if tinted else None,
         )
 
-        # 2. Handle input images based on count
-        if len(input_images) == 1 and not variants.light:
-            # Single input = light variant (unless used as reference)
-            variants.light = _load_image(input_images[0])
-
-        elif len(input_images) == 2 and not (variants.dark or variants.tinted):
-            # Two inputs = light + dark
-            if not variants.light:
-                variants.light = _load_image(input_images[0])
-            variants.dark = _load_image(input_images[1])
-
-        elif len(input_images) == 3 and not (variants.dark or variants.tinted):
-            # Three inputs = light + dark + tinted
-            if not variants.light:
-                variants.light = _load_image(input_images[0])
-            variants.dark = _load_image(input_images[1])
-            variants.tinted = _load_image(input_images[2])
+        # 2. Load style references (input_images are ONLY references, not variants)
+        # Use --light/--dark/--tinted for explicit variant files
+        reference_images: List[Image.Image] = [
+            _load_image(p) for p in input_images
+        ]
 
         # 3. Determine what needs to be generated
         needs_light = variants.light is None
         needs_dark = themed and variants.dark is None
         needs_tinted = themed and variants.tinted is None
-
-        # 4. Reference images for style consistency (4+ inputs, or inputs not used as variants)
-        reference_images: List[Image.Image] = []
-        if len(input_images) >= 4:
-            reference_images = [_load_image(p) for p in input_images]
-        elif len(input_images) > 0 and not needs_light:
-            reference_images = [_load_image(p) for p in input_images]
 
         # 5. Generate missing variants (single API call)
         if needs_light or needs_dark or needs_tinted:

--- a/gemimg/icons/generator.py
+++ b/gemimg/icons/generator.py
@@ -80,6 +80,7 @@ class IconGenerator:
         icon_type: Optional[IconType] = None,
         themed: Optional[bool] = None,
         output_dir: Optional[Path] = None,
+        google_search: bool = False,
     ) -> IconGenerationResult:
         """
         End-to-end icon generation with flexible input handling.
@@ -89,6 +90,7 @@ class IconGenerator:
         - 1 image: Use as light variant OR as style reference
         - 2-3 images: Interpret as light/dark/tinted (skip generation)
         - 4+ images: Use all as style references for generation
+          (Gemini 3 Pro supports up to 14 input images vs 6 for Flash)
 
         Explicit variant files (--light, --dark, --tinted) take precedence.
 
@@ -101,6 +103,7 @@ class IconGenerator:
             icon_type: Override config icon type
             themed: Override config themed setting
             output_dir: Override config output directory
+            google_search: Enable Google Search grounding (Gemini 3 Pro only)
 
         Returns:
             IconGenerationResult with variants and output paths
@@ -170,6 +173,7 @@ class IconGenerator:
                 aspect_ratio="1:1",
                 image_size="1K",
                 save=False,
+                google_search=google_search,
             )
 
             if result and result.images:
@@ -185,7 +189,8 @@ class IconGenerator:
                     variants.tinted = result.images[idx]
                     idx += 1
 
-                api_calls = 1
+                # Note: GemImg._generate_multiple makes n separate API calls
+                api_calls = n_outputs
             else:
                 raise RuntimeError("Failed to generate icon images")
 

--- a/gemimg/icons/generator.py
+++ b/gemimg/icons/generator.py
@@ -1,0 +1,288 @@
+"""Icon generation orchestration."""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+from PIL import Image
+
+from ..gemimg import GemImg
+from .constants import (
+    APP_ICON_PROMPT,
+    MENU_ICON_PROMPT,
+    PRESET_PLATFORMS,
+    THEMED_ICON_PROMPT,
+    IconType,
+    Platform,
+    Preset,
+)
+from .platforms import get_processor
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IconVariants:
+    """Container for all icon variants."""
+
+    light: Optional[Image.Image] = None
+    dark: Optional[Image.Image] = None
+    tinted: Optional[Image.Image] = None
+
+
+@dataclass
+class IconGenerationResult:
+    """Result of icon generation."""
+
+    variants: IconVariants
+    output_paths: Dict[str, List[Path]] = field(default_factory=dict)
+    api_calls: int = 0
+
+
+@dataclass
+class IconGeneratorConfig:
+    """Configuration for icon generation."""
+
+    icon_type: IconType = IconType.APP_ICON
+    platforms: Set[Platform] = field(default_factory=lambda: set(PRESET_PLATFORMS[Preset.ALL]))
+    themed: bool = False
+    macos_shadow: bool = True
+    validate_safe_zone: bool = True
+    output_dir: Path = field(default_factory=lambda: Path("icons"))
+
+
+class IconGenerator:
+    """
+    End-to-end icon generation pipeline.
+
+    Orchestrates AI generation and platform-specific post-processing.
+    """
+
+    def __init__(self, gemimg: Optional[GemImg] = None, config: Optional[IconGeneratorConfig] = None):
+        """
+        Initialize the IconGenerator.
+
+        Args:
+            gemimg: GemImg instance for AI generation. If None, will be created on demand.
+            config: Configuration for icon generation.
+        """
+        self.gemimg = gemimg
+        self.config = config or IconGeneratorConfig()
+
+    def generate(
+        self,
+        prompt: Optional[str] = None,
+        input_images: Optional[List[Path]] = None,
+        light: Optional[Path] = None,
+        dark: Optional[Path] = None,
+        tinted: Optional[Path] = None,
+        icon_type: Optional[IconType] = None,
+        themed: Optional[bool] = None,
+        output_dir: Optional[Path] = None,
+    ) -> IconGenerationResult:
+        """
+        End-to-end icon generation with flexible input handling.
+
+        Input Image Handling:
+        - 0 images: Generate from prompt (n=1 or n=3 if themed)
+        - 1 image: Use as light variant OR as style reference
+        - 2-3 images: Interpret as light/dark/tinted (skip generation)
+        - 4+ images: Use all as style references for generation
+
+        Explicit variant files (--light, --dark, --tinted) take precedence.
+
+        Args:
+            prompt: Text prompt for generation
+            input_images: List of input image paths
+            light: Explicit light variant file
+            dark: Explicit dark variant file
+            tinted: Explicit tinted variant file
+            icon_type: Override config icon type
+            themed: Override config themed setting
+            output_dir: Override config output directory
+
+        Returns:
+            IconGenerationResult with variants and output paths
+        """
+        # Apply overrides
+        icon_type = icon_type or self.config.icon_type
+        themed = themed if themed is not None else self.config.themed
+        output_dir = output_dir or self.config.output_dir
+
+        api_calls = 0
+        input_images = input_images or []
+
+        # 1. Resolve explicit variant files (highest priority)
+        variants = IconVariants(
+            light=Image.open(light) if light else None,
+            dark=Image.open(dark) if dark else None,
+            tinted=Image.open(tinted) if tinted else None,
+        )
+
+        # 2. Handle input images based on count
+        if len(input_images) == 1 and not variants.light:
+            # Single input = light variant (unless used as reference)
+            variants.light = Image.open(input_images[0])
+
+        elif len(input_images) == 2 and not (variants.dark or variants.tinted):
+            # Two inputs = light + dark
+            if not variants.light:
+                variants.light = Image.open(input_images[0])
+            variants.dark = Image.open(input_images[1])
+
+        elif len(input_images) == 3 and not (variants.dark or variants.tinted):
+            # Three inputs = light + dark + tinted
+            if not variants.light:
+                variants.light = Image.open(input_images[0])
+            variants.dark = Image.open(input_images[1])
+            variants.tinted = Image.open(input_images[2])
+
+        # 3. Determine what needs to be generated
+        needs_light = variants.light is None
+        needs_dark = themed and variants.dark is None
+        needs_tinted = themed and variants.tinted is None
+
+        # 4. Reference images for style consistency (4+ inputs, or inputs not used as variants)
+        reference_images: List[Image.Image] = []
+        if len(input_images) >= 4:
+            reference_images = [Image.open(p) for p in input_images]
+        elif len(input_images) > 0 and not needs_light:
+            reference_images = [Image.open(p) for p in input_images]
+
+        # 5. Generate missing variants (single API call)
+        if needs_light or needs_dark or needs_tinted:
+            if not prompt:
+                raise ValueError("Prompt is required when generating icons")
+
+            if not self.gemimg:
+                raise ValueError("GemImg instance is required for generation")
+
+            n_outputs = sum([needs_light, needs_dark, needs_tinted])
+            gen_prompt = self._build_generation_prompt(
+                icon_type, prompt, needs_light, needs_dark, needs_tinted
+            )
+
+            result = self.gemimg.generate(
+                prompt=gen_prompt,
+                imgs=reference_images if reference_images else None,
+                n=n_outputs,
+                aspect_ratio="1:1",
+                image_size="1K",
+                save=False,
+            )
+
+            if result and result.images:
+                # Assign generated images to missing variants
+                idx = 0
+                if needs_light:
+                    variants.light = result.images[idx]
+                    idx += 1
+                if needs_dark:
+                    variants.dark = result.images[idx]
+                    idx += 1
+                if needs_tinted:
+                    variants.tinted = result.images[idx]
+                    idx += 1
+
+                api_calls = 1
+            else:
+                raise RuntimeError("Failed to generate icon images")
+
+        # 6. Post-process for all platforms (PIL only, 0 API calls)
+        output_paths = self._postprocess_all_platforms(variants, output_dir, icon_type)
+
+        return IconGenerationResult(
+            variants=variants,
+            output_paths=output_paths,
+            api_calls=api_calls,
+        )
+
+    def _build_generation_prompt(
+        self,
+        icon_type: IconType,
+        user_prompt: str,
+        needs_light: bool,
+        needs_dark: bool,
+        needs_tinted: bool,
+    ) -> str:
+        """Build the appropriate prompt based on what needs to be generated."""
+        # Get base prompt for icon type
+        if icon_type == IconType.APP_ICON:
+            base_prompt = APP_ICON_PROMPT.format(user_prompt=user_prompt)
+        elif icon_type == IconType.MENU_ICON:
+            base_prompt = MENU_ICON_PROMPT.format(user_prompt=user_prompt)
+        else:
+            base_prompt = user_prompt
+
+        # If generating multiple variants, use themed prompt
+        if sum([needs_light, needs_dark, needs_tinted]) > 1:
+            return THEMED_ICON_PROMPT.format(base_prompt=base_prompt)
+
+        return base_prompt
+
+    def _postprocess_all_platforms(
+        self,
+        variants: IconVariants,
+        output_dir: Path,
+        icon_type: IconType,
+    ) -> Dict[str, List[Path]]:
+        """Post-process icons for all configured platforms."""
+        output_paths: Dict[str, List[Path]] = {}
+
+        # Process each variant
+        variant_images = [
+            ("light", variants.light),
+            ("dark", variants.dark),
+            ("tinted", variants.tinted),
+        ]
+
+        for variant_name, variant_image in variant_images:
+            if variant_image is None:
+                continue
+
+            for platform in self.config.platforms:
+                # Build platform-specific kwargs
+                kwargs = {}
+                if platform == Platform.MACOS:
+                    kwargs["apply_shadow"] = self.config.macos_shadow
+                elif platform == Platform.ANDROID:
+                    kwargs["validate_safe_zone"] = self.config.validate_safe_zone
+
+                processor = get_processor(
+                    platform=platform,
+                    output_dir=output_dir,
+                    icon_type=icon_type,
+                    variant=variant_name,
+                    **kwargs,
+                )
+
+                processed = processor.process(variant_image)
+                saved = processor.save(processed)
+
+                key = f"{platform.value}/{variant_name}"
+                output_paths[key] = saved
+
+        return output_paths
+
+    @classmethod
+    def from_preset(
+        cls,
+        preset: Preset,
+        gemimg: Optional[GemImg] = None,
+        **kwargs,
+    ) -> "IconGenerator":
+        """
+        Create an IconGenerator with a preset platform configuration.
+
+        Args:
+            preset: Platform preset (MOBILE, DESKTOP, APPLE, ALL)
+            gemimg: GemImg instance for AI generation
+            **kwargs: Additional config options
+
+        Returns:
+            Configured IconGenerator instance
+        """
+        platforms = set(PRESET_PLATFORMS[preset])
+        config = IconGeneratorConfig(platforms=platforms, **kwargs)
+        return cls(gemimg=gemimg, config=config)

--- a/gemimg/icons/platforms.py
+++ b/gemimg/icons/platforms.py
@@ -167,7 +167,9 @@ class MacOSProcessor(PlatformProcessor):
     def _apply_shadow(self, icon: Image.Image) -> Image.Image:
         """Apply macOS-style drop shadow to icon."""
         try:
-            shadow = Image.open(self.shadow_template).convert("RGBA")
+            # Use context manager for proper file handle cleanup (RAII)
+            with Image.open(self.shadow_template) as shadow_file:
+                shadow = shadow_file.convert("RGBA").copy()
             # Resize shadow to match icon size
             shadow = shadow.resize(icon.size, Image.Resampling.LANCZOS)
 
@@ -178,7 +180,7 @@ class MacOSProcessor(PlatformProcessor):
             # Composite icon over shadow
             shadow.paste(icon, (0, 0), icon)
             return shadow
-        except Exception as e:
+        except (FileNotFoundError, OSError, IOError) as e:
             logger.warning(f"Failed to apply shadow template: {e}")
             return icon
 
@@ -288,31 +290,25 @@ class WindowsProcessor(PlatformProcessor):
         """
         Process source image for Windows.
 
-        Creates a multi-size ICO file.
+        Creates all size variants for ICO file.
+        Returns dict keyed by size string for use by save().
         """
-        # Prepare sizes for ICO
-        ico_images = []
+        results = {}
         for size in WINDOWS_ICO_SIZES:
             resized = source_image.resize(size, Image.Resampling.LANCZOS)
-            ico_images.append(resized)
-
-        # Return the largest size as the main image
-        # The actual ICO saving happens in save()
-        return {"icon.ico": source_image}
+            results[f"{size[0]}x{size[1]}"] = resized
+        return results
 
     def save(self, processed_images: Dict[str, Image.Image]) -> List[Path]:
-        """Save as multi-size ICO file."""
+        """Save as multi-size ICO file using already-processed images."""
         platform_dir = self.output_dir / self.platform.value / self.variant
         platform_dir.mkdir(parents=True, exist_ok=True)
 
-        saved_paths = []
-        source = list(processed_images.values())[0]
-
-        # Create all size variants
-        ico_images = []
-        for size in WINDOWS_ICO_SIZES:
-            resized = source.resize(size, Image.Resampling.LANCZOS)
-            ico_images.append(resized)
+        # Collect images in order matching WINDOWS_ICO_SIZES
+        ico_images = [
+            processed_images[f"{size[0]}x{size[1]}"]
+            for size in WINDOWS_ICO_SIZES
+        ]
 
         # Save as ICO with all sizes
         ico_path = platform_dir / "icon.ico"
@@ -322,10 +318,9 @@ class WindowsProcessor(PlatformProcessor):
             sizes=WINDOWS_ICO_SIZES,
             append_images=ico_images[1:],
         )
-        saved_paths.append(ico_path)
         logger.debug(f"Saved: {ico_path}")
 
-        return saved_paths
+        return [ico_path]
 
 
 class PWAProcessor(PlatformProcessor):

--- a/gemimg/icons/platforms.py
+++ b/gemimg/icons/platforms.py
@@ -238,16 +238,19 @@ class AndroidProcessor(PlatformProcessor):
         safe_margin = int(width * (1 - ANDROID_SAFE_ZONE_PERCENT) / 2)
 
         # Check if there are non-transparent pixels near the edges
+        # A pixel is outside safe zone if it's near ANY edge (left, right, top, or bottom)
         pixels = img.load()
         edge_content = False
 
         for x in range(width):
             for y in range(height):
-                if x < safe_margin or x >= width - safe_margin:
-                    if y < safe_margin or y >= height - safe_margin:
-                        if pixels[x, y][3] > 128:  # Non-transparent
-                            edge_content = True
-                            break
+                # Check if pixel is outside safe zone on ANY axis (OR, not AND)
+                is_outside_horizontal = x < safe_margin or x >= width - safe_margin
+                is_outside_vertical = y < safe_margin or y >= height - safe_margin
+                if is_outside_horizontal or is_outside_vertical:
+                    if pixels[x, y][3] > 128:  # Non-transparent
+                        edge_content = True
+                        break
             if edge_content:
                 break
 

--- a/gemimg/icons/platforms.py
+++ b/gemimg/icons/platforms.py
@@ -1,0 +1,436 @@
+"""Platform-specific icon processors for post-processing."""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from PIL import Image
+
+from .constants import (
+    ANDROID_ICON_SPECS,
+    ANDROID_SAFE_ZONE_PERCENT,
+    IOS_ICON_SPECS,
+    MACOS_ICON_SPECS,
+    PWA_ICON_SPECS,
+    PWA_MASKABLE_PADDING_PERCENT,
+    WINDOWS_ICO_SIZES,
+    IconSpec,
+    IconType,
+    Platform,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PlatformProcessor(ABC):
+    """Abstract base class for platform-specific icon processing."""
+
+    platform: Platform
+
+    def __init__(
+        self,
+        output_dir: Path,
+        icon_type: IconType = IconType.APP_ICON,
+        variant: str = "light",
+    ):
+        """
+        Initialize the processor.
+
+        Args:
+            output_dir: Base output directory for icons
+            icon_type: Type of icon being processed
+            variant: Icon variant (light, dark, tinted)
+        """
+        self.output_dir = output_dir
+        self.icon_type = icon_type
+        self.variant = variant
+
+    @abstractmethod
+    def get_specs(self) -> List[IconSpec]:
+        """Return the icon specifications for this platform."""
+        pass
+
+    @abstractmethod
+    def process(self, source_image: Image.Image) -> Dict[str, Image.Image]:
+        """
+        Process the source image for this platform.
+
+        Args:
+            source_image: The source icon image
+
+        Returns:
+            Dictionary mapping filename to processed image
+        """
+        pass
+
+    def save(self, processed_images: Dict[str, Image.Image]) -> List[Path]:
+        """
+        Save processed images to the output directory.
+
+        Args:
+            processed_images: Dictionary mapping filename to image
+
+        Returns:
+            List of saved file paths
+        """
+        platform_dir = self.output_dir / self.platform.value / self.variant
+        platform_dir.mkdir(parents=True, exist_ok=True)
+
+        saved_paths = []
+        for filename, img in processed_images.items():
+            path = platform_dir / filename
+            img.save(str(path))
+            saved_paths.append(path)
+            logger.debug(f"Saved: {path}")
+
+        return saved_paths
+
+
+class IOSProcessor(PlatformProcessor):
+    """iOS/iPadOS icon processor."""
+
+    platform = Platform.IOS
+
+    def get_specs(self) -> List[IconSpec]:
+        return IOS_ICON_SPECS
+
+    def process(self, source_image: Image.Image) -> Dict[str, Image.Image]:
+        """
+        Process source image for iOS.
+
+        For app icons: Convert RGBA to RGB (no transparency allowed).
+        For menu icons: Preserve transparency.
+        """
+        results = {}
+
+        for spec in self.get_specs():
+            # Resize to target size
+            resized = source_image.resize(spec.size, Image.Resampling.LANCZOS)
+
+            # For app icons, ensure no transparency
+            if self.icon_type == IconType.APP_ICON and resized.mode == "RGBA":
+                # Create RGB image with white background
+                rgb = Image.new("RGB", resized.size, (255, 255, 255))
+                rgb.paste(resized, mask=resized.split()[3])
+                resized = rgb
+
+            filename = f"AppIcon-{spec.filename_suffix}.png"
+            results[filename] = resized
+
+        return results
+
+
+class MacOSProcessor(PlatformProcessor):
+    """macOS icon processor with optional shadow template."""
+
+    platform = Platform.MACOS
+
+    def __init__(
+        self,
+        output_dir: Path,
+        icon_type: IconType = IconType.APP_ICON,
+        variant: str = "light",
+        apply_shadow: bool = True,
+        shadow_template: Optional[Path] = None,
+    ):
+        super().__init__(output_dir, icon_type, variant)
+        self.apply_shadow = apply_shadow
+        self.shadow_template = shadow_template
+
+    def get_specs(self) -> List[IconSpec]:
+        return MACOS_ICON_SPECS
+
+    def process(self, source_image: Image.Image) -> Dict[str, Image.Image]:
+        """
+        Process source image for macOS.
+
+        Optionally applies drop shadow template.
+        """
+        results = {}
+
+        for spec in self.get_specs():
+            # Calculate actual output size (accounting for @2x)
+            output_size = spec.scaled_size
+            resized = source_image.resize(output_size, Image.Resampling.LANCZOS)
+
+            # Apply shadow template if available and enabled
+            if self.apply_shadow and self.shadow_template and self.shadow_template.exists():
+                resized = self._apply_shadow(resized)
+
+            filename = f"AppIcon-{spec.filename_suffix}.png"
+            results[filename] = resized
+
+        return results
+
+    def _apply_shadow(self, icon: Image.Image) -> Image.Image:
+        """Apply macOS-style drop shadow to icon."""
+        try:
+            shadow = Image.open(self.shadow_template).convert("RGBA")
+            # Resize shadow to match icon size
+            shadow = shadow.resize(icon.size, Image.Resampling.LANCZOS)
+
+            # Ensure icon has alpha channel
+            if icon.mode != "RGBA":
+                icon = icon.convert("RGBA")
+
+            # Composite icon over shadow
+            shadow.paste(icon, (0, 0), icon)
+            return shadow
+        except Exception as e:
+            logger.warning(f"Failed to apply shadow template: {e}")
+            return icon
+
+
+class AndroidProcessor(PlatformProcessor):
+    """Android icon processor with adaptive icon support."""
+
+    platform = Platform.ANDROID
+
+    def __init__(
+        self,
+        output_dir: Path,
+        icon_type: IconType = IconType.APP_ICON,
+        variant: str = "light",
+        validate_safe_zone: bool = True,
+    ):
+        super().__init__(output_dir, icon_type, variant)
+        self.validate_safe_zone = validate_safe_zone
+
+    def get_specs(self) -> List[IconSpec]:
+        return ANDROID_ICON_SPECS
+
+    def process(self, source_image: Image.Image) -> Dict[str, Image.Image]:
+        """
+        Process source image for Android.
+
+        Validates safe zone for adaptive icons.
+        """
+        results = {}
+
+        # Validate safe zone if enabled
+        if self.validate_safe_zone:
+            self._check_safe_zone(source_image)
+
+        for spec in self.get_specs():
+            resized = source_image.resize(spec.size, Image.Resampling.LANCZOS)
+            filename = f"ic_launcher-{spec.filename_suffix}.png"
+            results[filename] = resized
+
+        # Generate monochrome variant for themed icons (from tinted variant)
+        if self.variant == "tinted":
+            mono = self._create_monochrome(source_image)
+            results["ic_launcher_monochrome.png"] = mono
+
+        return results
+
+    def _check_safe_zone(self, img: Image.Image) -> None:
+        """
+        Check if content is within the 66% safe zone.
+
+        Logs a warning if content appears outside the safe zone.
+        """
+        if img.mode != "RGBA":
+            return
+
+        width, height = img.size
+        safe_margin = int(width * (1 - ANDROID_SAFE_ZONE_PERCENT) / 2)
+
+        # Check if there are non-transparent pixels near the edges
+        pixels = img.load()
+        edge_content = False
+
+        for x in range(width):
+            for y in range(height):
+                if x < safe_margin or x >= width - safe_margin:
+                    if y < safe_margin or y >= height - safe_margin:
+                        if pixels[x, y][3] > 128:  # Non-transparent
+                            edge_content = True
+                            break
+            if edge_content:
+                break
+
+        if edge_content:
+            logger.warning(
+                "Icon content may extend beyond Android adaptive icon safe zone (66%). "
+                "Content near edges may be clipped on some devices."
+            )
+
+    def _create_monochrome(self, img: Image.Image) -> Image.Image:
+        """Create monochrome version from tinted icon."""
+        if img.mode != "RGBA":
+            img = img.convert("RGBA")
+
+        # Extract alpha channel as the monochrome mask
+        _, _, _, alpha = img.split()
+
+        # Create a white silhouette on transparent background
+        mono = Image.new("RGBA", img.size, (0, 0, 0, 0))
+        white = Image.new("RGBA", img.size, (255, 255, 255, 255))
+        mono.paste(white, mask=alpha)
+
+        return mono
+
+
+class WindowsProcessor(PlatformProcessor):
+    """Windows ICO file processor."""
+
+    platform = Platform.WINDOWS
+
+    def get_specs(self) -> List[IconSpec]:
+        return [IconSpec(size[0], size[1]) for size in WINDOWS_ICO_SIZES]
+
+    def process(self, source_image: Image.Image) -> Dict[str, Image.Image]:
+        """
+        Process source image for Windows.
+
+        Creates a multi-size ICO file.
+        """
+        # Prepare sizes for ICO
+        ico_images = []
+        for size in WINDOWS_ICO_SIZES:
+            resized = source_image.resize(size, Image.Resampling.LANCZOS)
+            ico_images.append(resized)
+
+        # Return the largest size as the main image
+        # The actual ICO saving happens in save()
+        return {"icon.ico": source_image}
+
+    def save(self, processed_images: Dict[str, Image.Image]) -> List[Path]:
+        """Save as multi-size ICO file."""
+        platform_dir = self.output_dir / self.platform.value / self.variant
+        platform_dir.mkdir(parents=True, exist_ok=True)
+
+        saved_paths = []
+        source = list(processed_images.values())[0]
+
+        # Create all size variants
+        ico_images = []
+        for size in WINDOWS_ICO_SIZES:
+            resized = source.resize(size, Image.Resampling.LANCZOS)
+            ico_images.append(resized)
+
+        # Save as ICO with all sizes
+        ico_path = platform_dir / "icon.ico"
+        ico_images[0].save(
+            str(ico_path),
+            format="ICO",
+            sizes=WINDOWS_ICO_SIZES,
+            append_images=ico_images[1:],
+        )
+        saved_paths.append(ico_path)
+        logger.debug(f"Saved: {ico_path}")
+
+        return saved_paths
+
+
+class PWAProcessor(PlatformProcessor):
+    """Progressive Web App icon processor."""
+
+    platform = Platform.PWA
+
+    def get_specs(self) -> List[IconSpec]:
+        return PWA_ICON_SPECS
+
+    def process(self, source_image: Image.Image) -> Dict[str, Image.Image]:
+        """
+        Process source image for PWA.
+
+        Creates standard and maskable icon variants.
+        """
+        results = {}
+
+        for spec in self.get_specs():
+            resized = source_image.resize(spec.size, Image.Resampling.LANCZOS)
+
+            if spec.purpose == "maskable":
+                # Add padding for maskable icons
+                resized = self._add_maskable_padding(resized)
+
+            filename = f"icon-{spec.filename_suffix}.png"
+            results[filename] = resized
+
+        return results
+
+    def _add_maskable_padding(self, img: Image.Image) -> Image.Image:
+        """Add 10% padding for maskable PWA icons."""
+        width, height = img.size
+        padding = int(width * PWA_MASKABLE_PADDING_PERCENT)
+
+        # Calculate the inner size
+        inner_size = width - (2 * padding)
+
+        # Resize the icon to fit in the inner area
+        resized = img.resize((inner_size, inner_size), Image.Resampling.LANCZOS)
+
+        # Create a new image with white background
+        padded = Image.new("RGB", (width, height), (255, 255, 255))
+
+        # Center the resized icon
+        padded.paste(resized, (padding, padding))
+
+        return padded
+
+    def save(self, processed_images: Dict[str, Image.Image]) -> List[Path]:
+        """Save icons and generate manifest-icons.json."""
+        saved_paths = super().save(processed_images)
+
+        # Generate manifest-icons.json
+        manifest = self._generate_manifest()
+        manifest_path = self.output_dir / self.platform.value / self.variant / "manifest-icons.json"
+
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+
+        saved_paths.append(manifest_path)
+        logger.debug(f"Saved: {manifest_path}")
+
+        return saved_paths
+
+    def _generate_manifest(self) -> List[Dict]:
+        """Generate the icons array for web manifest."""
+        icons = []
+        for spec in self.get_specs():
+            icons.append({
+                "src": f"icon-{spec.filename_suffix}.png",
+                "sizes": f"{spec.width}x{spec.height}",
+                "type": "image/png",
+                "purpose": spec.purpose,
+            })
+        return icons
+
+
+def get_processor(
+    platform: Platform,
+    output_dir: Path,
+    icon_type: IconType = IconType.APP_ICON,
+    variant: str = "light",
+    **kwargs,
+) -> PlatformProcessor:
+    """
+    Factory function to get the appropriate processor for a platform.
+
+    Args:
+        platform: Target platform
+        output_dir: Base output directory
+        icon_type: Type of icon
+        variant: Icon variant (light, dark, tinted)
+        **kwargs: Additional processor-specific options
+
+    Returns:
+        Appropriate PlatformProcessor instance
+    """
+    processors = {
+        Platform.IOS: IOSProcessor,
+        Platform.MACOS: MacOSProcessor,
+        Platform.ANDROID: AndroidProcessor,
+        Platform.WINDOWS: WindowsProcessor,
+        Platform.PWA: PWAProcessor,
+    }
+
+    processor_class = processors.get(platform)
+    if not processor_class:
+        raise ValueError(f"Unsupported platform: {platform}")
+
+    return processor_class(output_dir, icon_type, variant, **kwargs)

--- a/gemimg/utils.py
+++ b/gemimg/utils.py
@@ -115,7 +115,8 @@ def img_to_b64(img: Union[str, Image.Image], resize: bool = True) -> str:
         The base64-encoded string of the image.
     """
     if isinstance(img, str):
-        img = Image.open(img)
+        with Image.open(img) as opened:
+            img = opened.copy()
     if resize:
         img = resize_image(img)
 
@@ -234,13 +235,13 @@ def composite_images(
         raise ValueError("Images list cannot be empty")
 
     # Load all images and ensure they're PIL Image objects
+    # Use context managers for file paths to avoid file handle leaks
     loaded_images: List[Image.Image] = []
     for img in images:
         if isinstance(img, str):
-            # It's a file path
-            loaded_images.append(Image.open(img))
+            with Image.open(img) as opened:
+                loaded_images.append(opened.copy())
         else:
-            # It's already a PIL Image
             loaded_images.append(img)
 
     num_images = len(loaded_images)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "Pillow>=11.3.0",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0", "pytest-cov>=4.1.0", "responses>=0.25.0", "pytest-mock>=3.12.0"]
+
 [project.urls]
 Homepage = "https://github.com/minimaxir/gemimg"
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# gemimg tests package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,81 +1,9 @@
 """Pytest configuration and fixtures for gemimg tests."""
 
 import pytest
-from unittest.mock import MagicMock, patch
-from PIL import Image
-import io
-import base64
 
 
 @pytest.fixture
 def api_key():
     """Provide a test API key."""
     return "test-api-key-12345"
-
-
-@pytest.fixture
-def mock_httpx_client():
-    """Provide a mocked httpx.Client."""
-    with patch("httpx.Client") as mock_client:
-        yield mock_client
-
-
-@pytest.fixture
-def sample_image():
-    """Create a simple test image."""
-    img = Image.new("RGB", (100, 100), color="red")
-    return img
-
-
-@pytest.fixture
-def sample_image_b64(sample_image):
-    """Create a base64-encoded test image."""
-    buffer = io.BytesIO()
-    sample_image.save(buffer, format="PNG")
-    return base64.b64encode(buffer.getvalue()).decode("utf-8")
-
-
-@pytest.fixture
-def mock_successful_response(sample_image_b64):
-    """Create a mock successful API response."""
-    return {
-        "responseId": "test-response-id",
-        "candidates": [
-            {
-                "content": {
-                    "parts": [
-                        {
-                            "inlineData": {
-                                "mimeType": "image/png",
-                                "data": sample_image_b64,
-                            }
-                        }
-                    ]
-                },
-                "finishReason": "STOP",
-            }
-        ],
-        "usageMetadata": {
-            "promptTokenCount": 10,
-            "candidatesTokenCount": 20,
-        },
-    }
-
-
-@pytest.fixture
-def mock_error_response():
-    """Create a mock error API response."""
-    return {
-        "error": {
-            "code": 400,
-            "message": "Invalid request",
-        }
-    }
-
-
-@pytest.fixture
-def gemimg_instance(api_key, mock_httpx_client):
-    """Create a GemImg instance with mocked client."""
-    from gemimg import GemImg
-
-    return GemImg(api_key=api_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Pytest configuration and fixtures for gemimg tests."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from PIL import Image
+import io
+import base64
+
+
+@pytest.fixture
+def api_key():
+    """Provide a test API key."""
+    return "test-api-key-12345"
+
+
+@pytest.fixture
+def mock_httpx_client():
+    """Provide a mocked httpx.Client."""
+    with patch("httpx.Client") as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def sample_image():
+    """Create a simple test image."""
+    img = Image.new("RGB", (100, 100), color="red")
+    return img
+
+
+@pytest.fixture
+def sample_image_b64(sample_image):
+    """Create a base64-encoded test image."""
+    buffer = io.BytesIO()
+    sample_image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+
+@pytest.fixture
+def mock_successful_response(sample_image_b64):
+    """Create a mock successful API response."""
+    return {
+        "responseId": "test-response-id",
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": sample_image_b64,
+                            }
+                        }
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+        },
+    }
+
+
+@pytest.fixture
+def mock_error_response():
+    """Create a mock error API response."""
+    return {
+        "error": {
+            "code": 400,
+            "message": "Invalid request",
+        }
+    }
+
+
+@pytest.fixture
+def gemimg_instance(api_key, mock_httpx_client):
+    """Create a GemImg instance with mocked client."""
+    from gemimg import GemImg
+
+    return GemImg(api_key=api_key)

--- a/tests/test_gemimg.py
+++ b/tests/test_gemimg.py
@@ -213,3 +213,162 @@ class TestIsProProperty:
         """Should return False for flash models."""
         gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
         assert gem.is_pro is False
+
+
+class TestErrorHandling:
+    """Tests for error handling and edge cases."""
+
+    def test_generate_returns_none_on_timeout(self, api_key):
+        """Should return None when API request times out."""
+        import httpx
+
+        gem = GemImg(api_key=api_key)
+        with patch.object(gem, "client") as mock_client:
+            mock_client.post.side_effect = httpx.TimeoutException("Request timed out")
+            result = gem.generate(prompt="test")
+            assert result is None
+
+    def test_generate_returns_none_on_http_error(self, api_key):
+        """Should return None when API returns HTTP error status."""
+        import httpx
+
+        gem = GemImg(api_key=api_key)
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "Server Error",
+                request=MagicMock(),
+                response=MagicMock(status_code=500, text="Internal Server Error"),
+            )
+            mock_client.post.return_value = mock_response
+            result = gem.generate(prompt="test")
+            assert result is None
+
+    def test_generate_returns_none_on_api_error_response(self, api_key):
+        """Should return None and log error when API returns error object."""
+        gem = GemImg(api_key=api_key)
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {
+                "error": {"code": 429, "message": "Rate limit exceeded"}
+            }
+            mock_client.post.return_value = mock_response
+            result = gem.generate(prompt="test")
+            assert result is None
+
+    def test_generate_returns_none_on_prohibited_content(self, api_key):
+        """Should return None when API returns PROHIBITED_CONTENT."""
+        gem = GemImg(api_key=api_key)
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "candidates": [{"finishReason": "PROHIBITED_CONTENT"}],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 0},
+            }
+            mock_client.post.return_value = mock_response
+            result = gem.generate(prompt="test")
+            assert result is None
+
+    def test_generate_returns_none_on_malformed_response(self, api_key):
+        """Should return None when API response is missing expected fields."""
+        gem = GemImg(api_key=api_key)
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            # Missing 'candidates' key
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "usageMetadata": {"promptTokenCount": 10},
+            }
+            mock_client.post.return_value = mock_response
+            result = gem.generate(prompt="test")
+            assert result is None
+
+    def test_generate_raises_without_prompt_or_imgs(self, api_key):
+        """Should raise ValueError when neither prompt nor imgs provided."""
+        gem = GemImg(api_key=api_key)
+        with pytest.raises(ValueError, match=r"Either 'prompt' or 'imgs' must be provided"):
+            gem.generate()
+
+
+class TestGenerateMultiple:
+    """Tests for multiple image generation."""
+
+    def test_generate_multiple_accumulates_results(self, api_key):
+        """Generating n>1 images should accumulate all results."""
+        gem = GemImg(api_key=api_key)
+        valid_b64 = create_valid_b64_image()
+
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"inlineData": {"mimeType": "image/png", "data": valid_b64}}
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+            }
+            mock_client.post.return_value = mock_response
+
+            result = gem.generate(prompt="test", n=3, temperature=1.0)
+
+            assert result is not None
+            assert len(result.images) == 3
+            assert len(result.usages) == 3
+            assert mock_client.post.call_count == 3
+
+    def test_generate_multiple_handles_partial_failure(self, api_key):
+        """Should handle partial failures gracefully when some API calls fail."""
+        gem = GemImg(api_key=api_key)
+        valid_b64 = create_valid_b64_image()
+
+        call_count = [0]
+
+        def mock_post(*args, **kwargs):
+            call_count[0] += 1
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            if call_count[0] == 2:
+                # Second call fails
+                mock_response.json.return_value = {
+                    "error": {"code": 500, "message": "Internal error"}
+                }
+            else:
+                mock_response.json.return_value = {
+                    "responseId": "test",
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"inlineData": {"mimeType": "image/png", "data": valid_b64}}
+                                ]
+                            },
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+                }
+            return mock_response
+
+        with patch.object(gem, "client") as mock_client:
+            mock_client.post.side_effect = mock_post
+
+            # Should not crash, should return partial results
+            result = gem.generate(prompt="test", n=3, temperature=1.0)
+
+            # Either returns partial results or None, but should not crash
+            assert mock_client.post.call_count == 3
+            if result is not None:
+                # Partial success: got some images
+                assert len(result.images) >= 1

--- a/tests/test_gemimg.py
+++ b/tests/test_gemimg.py
@@ -1,0 +1,215 @@
+"""Tests for the GemImg class - Gemini 3 Pro Image support."""
+
+import base64
+import io
+import pytest
+from unittest.mock import MagicMock, patch
+from PIL import Image
+
+from gemimg import GemImg
+
+
+def create_valid_b64_image():
+    """Create a valid base64-encoded PNG image for testing."""
+    img = Image.new("RGB", (100, 100), color="red")
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+
+class TestIsGemini3Property:
+    """Tests for the is_gemini3 property detection."""
+
+    def test_is_gemini3_with_gemini3_pro_image_preview(self, api_key):
+        """Should return True for gemini-3-pro-image-preview model."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+        assert gem.is_gemini3 is True
+
+    def test_is_gemini3_with_gemini3_prefix(self, api_key):
+        """Should return True for any model starting with gemini-3."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro")
+        assert gem.is_gemini3 is True
+
+    def test_is_gemini3_with_flash_model(self, api_key):
+        """Should return False for gemini-2.5-flash-image model."""
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+        assert gem.is_gemini3 is False
+
+    def test_is_gemini3_with_default_model(self, api_key):
+        """Should return False for default model (gemini-2.5-flash-image)."""
+        gem = GemImg(api_key=api_key)
+        assert gem.is_gemini3 is False
+
+    def test_is_gemini3_with_pro_2_model(self, api_key):
+        """Should return False for gemini-2.0-pro model."""
+        gem = GemImg(api_key=api_key, model="gemini-2.0-pro-image")
+        assert gem.is_gemini3 is False
+
+
+class TestInputImageLimit:
+    """Tests for the input image count validation."""
+
+    def test_gemini3_allows_14_input_images(self, api_key):
+        """Gemini 3 Pro should allow up to 14 input images."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+        # Create 14 test images
+        imgs = [Image.new("RGB", (100, 100), color="red") for _ in range(14)]
+
+        # This should not raise an error when we implement validation
+        # For now, we're just setting up the test
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "candidates": [{"content": {"parts": []}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+            }
+            mock_client.post.return_value = mock_response
+
+            # Should not raise ValueError for 14 images on Gemini 3
+            try:
+                gem.generate(prompt="test", imgs=imgs)
+            except ValueError as e:
+                if "Maximum" in str(e) and "input images" in str(e):
+                    pytest.fail(f"Should allow 14 images for Gemini 3: {e}")
+                raise
+
+    def test_gemini3_rejects_15_input_images(self, api_key):
+        """Gemini 3 Pro should reject more than 14 input images."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+        imgs = [Image.new("RGB", (100, 100), color="red") for _ in range(15)]
+
+        with pytest.raises(ValueError, match=r"Maximum 14 input images"):
+            gem.generate(prompt="test", imgs=imgs)
+
+    def test_flash_model_allows_6_input_images(self, api_key):
+        """Flash model should allow up to 6 input images."""
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+        imgs = [Image.new("RGB", (100, 100), color="red") for _ in range(6)]
+
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "candidates": [{"content": {"parts": []}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+            }
+            mock_client.post.return_value = mock_response
+
+            try:
+                gem.generate(prompt="test", imgs=imgs)
+            except ValueError as e:
+                if "Maximum" in str(e) and "input images" in str(e):
+                    pytest.fail(f"Should allow 6 images for Flash: {e}")
+                raise
+
+    def test_flash_model_rejects_7_input_images(self, api_key):
+        """Flash model should reject more than 6 input images."""
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+        imgs = [Image.new("RGB", (100, 100), color="red") for _ in range(7)]
+
+        with pytest.raises(ValueError, match=r"Maximum 6 input images"):
+            gem.generate(prompt="test", imgs=imgs)
+
+
+class TestGoogleSearchGrounding:
+    """Tests for Google Search grounding parameter."""
+
+    def test_google_search_included_in_request(self, api_key):
+        """Google Search tool should be included in API request when enabled."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+        valid_b64 = create_valid_b64_image()
+
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "inlineData": {
+                                        "mimeType": "image/png",
+                                        "data": valid_b64,
+                                    }
+                                }
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+            }
+            mock_client.post.return_value = mock_response
+
+            gem.generate(prompt="current weather in Paris", google_search=True)
+
+            # Check that the API was called with googleSearch tool
+            call_args = mock_client.post.call_args
+            json_payload = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert "tools" in json_payload
+            assert {"googleSearch": {}} in json_payload["tools"]
+
+    def test_google_search_requires_gemini3(self, api_key):
+        """Google Search should raise error for non-Gemini 3 models."""
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+
+        with pytest.raises(
+            ValueError, match=r"Google Search grounding requires Gemini 3"
+        ):
+            gem.generate(prompt="test", google_search=True)
+
+    def test_google_search_disabled_by_default(self, api_key):
+        """Google Search should not be included when not explicitly enabled."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+        valid_b64 = create_valid_b64_image()
+
+        with patch.object(gem, "client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "responseId": "test",
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "inlineData": {
+                                        "mimeType": "image/png",
+                                        "data": valid_b64,
+                                    }
+                                }
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+            }
+            mock_client.post.return_value = mock_response
+
+            gem.generate(prompt="test")
+
+            # Check that tools is not in the request
+            call_args = mock_client.post.call_args
+            json_payload = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert "tools" not in json_payload
+
+
+class TestIsProProperty:
+    """Tests for the existing is_pro property (ensure no regression)."""
+
+    def test_is_pro_with_pro_model(self, api_key):
+        """Should return True for pro models."""
+        gem = GemImg(api_key=api_key, model="gemini-2.0-pro-image")
+        assert gem.is_pro is True
+
+    def test_is_pro_with_gemini3_pro(self, api_key):
+        """Should return True for gemini-3-pro-image-preview."""
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+        assert gem.is_pro is True
+
+    def test_is_pro_with_flash_model(self, api_key):
+        """Should return False for flash models."""
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+        assert gem.is_pro is False

--- a/tests/test_gemimg.py
+++ b/tests/test_gemimg.py
@@ -156,7 +156,7 @@ class TestGoogleSearchGrounding:
         gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
 
         with pytest.raises(
-            ValueError, match=r"Google Search grounding requires Gemini 3"
+            ValueError, match=r"Google Search grounding requires a Gemini 3 model"
         ):
             gem.generate(prompt="test", google_search=True)
 

--- a/tests/test_gemimg.py
+++ b/tests/test_gemimg.py
@@ -372,3 +372,81 @@ class TestGenerateMultiple:
             if result is not None:
                 # Partial success: got some images
                 assert len(result.images) >= 1
+
+
+class TestProOnlyOptionWarnings:
+    """Tests for warnings when Pro-only options are used with non-Pro models."""
+
+    def test_warns_when_system_prompt_used_with_flash(self, api_key, caplog):
+        """Should warn when system_prompt is used with Flash model."""
+        import logging
+
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+
+        with patch.object(gem, "client") as mock_client:
+            # Mock a failed response to avoid full execution
+            mock_client.post.side_effect = Exception("Test")
+
+            with caplog.at_level(logging.WARNING):
+                try:
+                    gem.generate(prompt="test", system_prompt="custom style")
+                except Exception:
+                    pass
+
+            assert any("system_prompt" in record.message.lower() for record in caplog.records)
+            assert any("pro" in record.message.lower() for record in caplog.records)
+
+    def test_warns_when_image_size_non_default_with_flash(self, api_key, caplog):
+        """Should warn when image_size differs from default with Flash model."""
+        import logging
+
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+
+        with patch.object(gem, "client") as mock_client:
+            mock_client.post.side_effect = Exception("Test")
+
+            with caplog.at_level(logging.WARNING):
+                try:
+                    gem.generate(prompt="test", image_size="4K")
+                except Exception:
+                    pass
+
+            assert any("image_size" in record.message.lower() for record in caplog.records)
+            assert any("pro" in record.message.lower() for record in caplog.records)
+
+    def test_no_warning_when_image_size_default_with_flash(self, api_key, caplog):
+        """Should NOT warn when image_size is default 2K with Flash model."""
+        import logging
+
+        gem = GemImg(api_key=api_key, model="gemini-2.5-flash-image")
+
+        with patch.object(gem, "client") as mock_client:
+            mock_client.post.side_effect = Exception("Test")
+
+            with caplog.at_level(logging.WARNING):
+                try:
+                    gem.generate(prompt="test", image_size="2K")
+                except Exception:
+                    pass
+
+            # Should not have image_size warning for default value
+            assert not any("image_size" in record.message.lower() for record in caplog.records)
+
+    def test_no_warning_with_pro_model(self, api_key, caplog):
+        """Should NOT warn when Pro-only options are used with Pro model."""
+        import logging
+
+        gem = GemImg(api_key=api_key, model="gemini-3-pro-image-preview")
+
+        with patch.object(gem, "client") as mock_client:
+            mock_client.post.side_effect = Exception("Test")
+
+            with caplog.at_level(logging.WARNING):
+                try:
+                    gem.generate(prompt="test", system_prompt="style", image_size="4K")
+                except Exception:
+                    pass
+
+            # Should not have any Pro-only option warnings
+            warning_messages = [r.message.lower() for r in caplog.records if r.levelno >= logging.WARNING]
+            assert not any("ignored" in msg for msg in warning_messages)

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,330 @@
+"""Tests for the icons module."""
+
+import pytest
+from pathlib import Path
+from PIL import Image
+import tempfile
+import json
+
+from gemimg.icons import (
+    Platform,
+    Preset,
+    IconSpec,
+    IconType,
+    IconGenerator,
+    IconGeneratorConfig,
+    IconVariants,
+)
+from gemimg.icons.constants import (
+    PRESET_PLATFORMS,
+    IOS_ICON_SPECS,
+    MACOS_ICON_SPECS,
+    ANDROID_ICON_SPECS,
+    WINDOWS_ICO_SIZES,
+    PWA_ICON_SPECS,
+)
+from gemimg.icons.platforms import (
+    IOSProcessor,
+    MacOSProcessor,
+    AndroidProcessor,
+    WindowsProcessor,
+    PWAProcessor,
+    get_processor,
+)
+
+
+@pytest.fixture
+def sample_icon():
+    """Create a sample 1024x1024 icon image."""
+    return Image.new("RGBA", (1024, 1024), color=(255, 0, 0, 255))
+
+
+@pytest.fixture
+def temp_output_dir():
+    """Create a temporary output directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+class TestPlatformEnum:
+    """Tests for Platform enum."""
+
+    def test_all_platforms_defined(self):
+        """All expected platforms should be defined."""
+        assert Platform.IOS.value == "ios"
+        assert Platform.MACOS.value == "macos"
+        assert Platform.ANDROID.value == "android"
+        assert Platform.WINDOWS.value == "windows"
+        assert Platform.PWA.value == "pwa"
+
+
+class TestPresetEnum:
+    """Tests for Preset enum and mappings."""
+
+    def test_mobile_preset(self):
+        """Mobile preset should include iOS and Android."""
+        platforms = PRESET_PLATFORMS[Preset.MOBILE]
+        assert Platform.IOS in platforms
+        assert Platform.ANDROID in platforms
+        assert len(platforms) == 2
+
+    def test_desktop_preset(self):
+        """Desktop preset should include macOS and Windows."""
+        platforms = PRESET_PLATFORMS[Preset.DESKTOP]
+        assert Platform.MACOS in platforms
+        assert Platform.WINDOWS in platforms
+        assert len(platforms) == 2
+
+    def test_apple_preset(self):
+        """Apple preset should include iOS and macOS."""
+        platforms = PRESET_PLATFORMS[Preset.APPLE]
+        assert Platform.IOS in platforms
+        assert Platform.MACOS in platforms
+        assert len(platforms) == 2
+
+    def test_all_preset(self):
+        """All preset should include all 5 platforms."""
+        platforms = PRESET_PLATFORMS[Preset.ALL]
+        assert len(platforms) == 5
+        assert Platform.IOS in platforms
+        assert Platform.MACOS in platforms
+        assert Platform.ANDROID in platforms
+        assert Platform.WINDOWS in platforms
+        assert Platform.PWA in platforms
+
+
+class TestIconSpec:
+    """Tests for IconSpec dataclass."""
+
+    def test_size_property(self):
+        """Size property should return (width, height) tuple."""
+        spec = IconSpec(512, 512)
+        assert spec.size == (512, 512)
+
+    def test_scaled_size_property(self):
+        """Scaled size should account for scale factor."""
+        spec = IconSpec(256, 256, scale=2)
+        assert spec.scaled_size == (512, 512)
+
+
+class TestIOSProcessor:
+    """Tests for iOS icon processor."""
+
+    def test_process_creates_all_sizes(self, sample_icon, temp_output_dir):
+        """iOS processor should create all required icon sizes."""
+        processor = IOSProcessor(temp_output_dir)
+        result = processor.process(sample_icon)
+
+        assert len(result) == len(IOS_ICON_SPECS)
+        for filename, img in result.items():
+            assert filename.startswith("AppIcon-")
+            assert filename.endswith(".png")
+
+    def test_app_icon_removes_transparency(self, temp_output_dir):
+        """App icon mode should convert RGBA to RGB."""
+        # Create image with transparency
+        rgba_icon = Image.new("RGBA", (1024, 1024), color=(255, 0, 0, 128))
+
+        processor = IOSProcessor(temp_output_dir, icon_type=IconType.APP_ICON)
+        result = processor.process(rgba_icon)
+
+        # Check first result is RGB
+        first_img = list(result.values())[0]
+        assert first_img.mode == "RGB"
+
+    def test_menu_icon_preserves_transparency(self, temp_output_dir):
+        """Menu icon mode should preserve transparency."""
+        rgba_icon = Image.new("RGBA", (1024, 1024), color=(255, 0, 0, 128))
+
+        processor = IOSProcessor(temp_output_dir, icon_type=IconType.MENU_ICON)
+        result = processor.process(rgba_icon)
+
+        first_img = list(result.values())[0]
+        assert first_img.mode == "RGBA"
+
+
+class TestMacOSProcessor:
+    """Tests for macOS icon processor."""
+
+    def test_process_creates_all_sizes(self, sample_icon, temp_output_dir):
+        """macOS processor should create all required sizes including @2x."""
+        processor = MacOSProcessor(temp_output_dir, apply_shadow=False)
+        result = processor.process(sample_icon)
+
+        assert len(result) == len(MACOS_ICON_SPECS)
+
+        # Check for @2x variants
+        filenames = list(result.keys())
+        assert any("@2x" in f for f in filenames)
+
+
+class TestAndroidProcessor:
+    """Tests for Android icon processor."""
+
+    def test_process_creates_all_densities(self, sample_icon, temp_output_dir):
+        """Android processor should create all density variants."""
+        processor = AndroidProcessor(temp_output_dir, validate_safe_zone=False)
+        result = processor.process(sample_icon)
+
+        assert len(result) == len(ANDROID_ICON_SPECS)
+
+        # Check for density suffixes
+        filenames = list(result.keys())
+        assert any("xxxhdpi" in f for f in filenames)
+        assert any("mdpi" in f for f in filenames)
+
+    def test_tinted_variant_creates_monochrome(self, sample_icon, temp_output_dir):
+        """Tinted variant should create monochrome icon."""
+        processor = AndroidProcessor(
+            temp_output_dir, variant="tinted", validate_safe_zone=False
+        )
+        result = processor.process(sample_icon)
+
+        assert "ic_launcher_monochrome.png" in result
+
+
+class TestWindowsProcessor:
+    """Tests for Windows ICO processor."""
+
+    def test_save_creates_ico_file(self, sample_icon, temp_output_dir):
+        """Windows processor should create multi-size ICO file."""
+        processor = WindowsProcessor(temp_output_dir)
+        processed = processor.process(sample_icon)
+        saved = processor.save(processed)
+
+        assert len(saved) == 1
+        assert saved[0].suffix == ".ico"
+        assert saved[0].exists()
+
+
+class TestPWAProcessor:
+    """Tests for PWA icon processor."""
+
+    def test_process_creates_all_sizes(self, sample_icon, temp_output_dir):
+        """PWA processor should create all required sizes."""
+        processor = PWAProcessor(temp_output_dir)
+        result = processor.process(sample_icon)
+
+        assert len(result) == len(PWA_ICON_SPECS)
+
+    def test_maskable_icons_have_padding(self, sample_icon, temp_output_dir):
+        """Maskable icons should have padding applied."""
+        processor = PWAProcessor(temp_output_dir)
+        result = processor.process(sample_icon)
+
+        # Check that maskable icons exist
+        maskable_files = [f for f in result.keys() if "maskable" in f]
+        assert len(maskable_files) > 0
+
+    def test_save_creates_manifest(self, sample_icon, temp_output_dir):
+        """PWA processor should create manifest-icons.json."""
+        processor = PWAProcessor(temp_output_dir)
+        processed = processor.process(sample_icon)
+        saved = processor.save(processed)
+
+        manifest_path = temp_output_dir / "pwa" / "light" / "manifest-icons.json"
+        assert manifest_path.exists()
+
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+            assert isinstance(manifest, list)
+            assert len(manifest) > 0
+            assert all("src" in item for item in manifest)
+            assert all("sizes" in item for item in manifest)
+
+
+class TestGetProcessor:
+    """Tests for processor factory function."""
+
+    def test_returns_correct_processor_types(self, temp_output_dir):
+        """Factory should return correct processor type for each platform."""
+        assert isinstance(get_processor(Platform.IOS, temp_output_dir), IOSProcessor)
+        assert isinstance(get_processor(Platform.MACOS, temp_output_dir), MacOSProcessor)
+        assert isinstance(get_processor(Platform.ANDROID, temp_output_dir), AndroidProcessor)
+        assert isinstance(get_processor(Platform.WINDOWS, temp_output_dir), WindowsProcessor)
+        assert isinstance(get_processor(Platform.PWA, temp_output_dir), PWAProcessor)
+
+
+class TestIconVariants:
+    """Tests for IconVariants dataclass."""
+
+    def test_default_values(self):
+        """Default values should be None."""
+        variants = IconVariants()
+        assert variants.light is None
+        assert variants.dark is None
+        assert variants.tinted is None
+
+    def test_with_images(self, sample_icon):
+        """Should accept image instances."""
+        variants = IconVariants(light=sample_icon, dark=sample_icon)
+        assert variants.light is not None
+        assert variants.dark is not None
+        assert variants.tinted is None
+
+
+class TestIconGeneratorConfig:
+    """Tests for IconGeneratorConfig."""
+
+    def test_default_values(self):
+        """Config should have sensible defaults."""
+        config = IconGeneratorConfig()
+        assert config.icon_type == IconType.APP_ICON
+        assert len(config.platforms) == 5  # ALL preset
+        assert config.themed is False
+        assert config.macos_shadow is True
+        assert config.validate_safe_zone is True
+
+    def test_custom_values(self):
+        """Config should accept custom values."""
+        config = IconGeneratorConfig(
+            icon_type=IconType.MENU_ICON,
+            platforms={Platform.IOS, Platform.ANDROID},
+            themed=True,
+        )
+        assert config.icon_type == IconType.MENU_ICON
+        assert len(config.platforms) == 2
+        assert config.themed is True
+
+
+class TestIconGenerator:
+    """Tests for IconGenerator orchestration."""
+
+    def test_generate_with_single_input(self, sample_icon, temp_output_dir):
+        """Should use single input as light variant."""
+        # Save sample icon to temp file
+        input_path = temp_output_dir / "input.png"
+        sample_icon.save(str(input_path))
+
+        config = IconGeneratorConfig(
+            platforms={Platform.IOS},
+            output_dir=temp_output_dir / "output",
+        )
+        generator = IconGenerator(gemimg=None, config=config)
+
+        result = generator.generate(
+            input_images=[input_path],
+        )
+
+        assert result.api_calls == 0  # No generation needed
+        assert result.variants.light is not None
+        assert "ios/light" in result.output_paths
+
+    def test_generate_requires_prompt_for_generation(self, temp_output_dir):
+        """Should raise error if generation needed but no prompt."""
+        config = IconGeneratorConfig(
+            platforms={Platform.IOS},
+            output_dir=temp_output_dir / "output",
+        )
+        generator = IconGenerator(gemimg=None, config=config)
+
+        with pytest.raises(ValueError, match="Prompt is required"):
+            generator.generate()
+
+    def test_from_preset(self):
+        """Should create generator from preset."""
+        generator = IconGenerator.from_preset(Preset.MOBILE)
+
+        assert Platform.IOS in generator.config.platforms
+        assert Platform.ANDROID in generator.config.platforms
+        assert len(generator.config.platforms) == 2

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -308,6 +308,35 @@ class TestIconGeneratorConfig:
         with pytest.raises(ValueError, match="At least one platform must be specified"):
             IconGeneratorConfig(platforms=set())
 
+    def test_image_size_validation(self):
+        """Should validate image_size is 1K, 2K, or 4K."""
+        # Valid sizes should work
+        assert IconGeneratorConfig(image_size="1K").image_size == "1K"
+        assert IconGeneratorConfig(image_size="2K").image_size == "2K"
+        assert IconGeneratorConfig(image_size="4K").image_size == "4K"
+
+        # Invalid sizes should raise
+        with pytest.raises(ValueError, match="image_size must be"):
+            IconGeneratorConfig(image_size="invalid")
+
+    def test_temperature_validation(self):
+        """Should validate temperature is between 0.0 and 2.0."""
+        # Valid temperatures should work
+        assert IconGeneratorConfig(temperature=0.0).temperature == 0.0
+        assert IconGeneratorConfig(temperature=1.0).temperature == 1.0
+        assert IconGeneratorConfig(temperature=2.0).temperature == 2.0
+
+        # Invalid temperatures should raise
+        with pytest.raises(ValueError, match="temperature must be between"):
+            IconGeneratorConfig(temperature=-0.1)
+        with pytest.raises(ValueError, match="temperature must be between"):
+            IconGeneratorConfig(temperature=2.1)
+
+    def test_system_prompt_override(self):
+        """Should accept custom system prompt."""
+        config = IconGeneratorConfig(system_prompt="Custom prompt for icons")
+        assert config.system_prompt == "Custom prompt for icons"
+
 
 class TestIconType:
     """Tests for IconType enum properties."""

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -371,11 +371,11 @@ class TestVariantEnum:
 class TestIconGenerator:
     """Tests for IconGenerator orchestration."""
 
-    def test_generate_with_single_input(self, sample_icon, temp_output_dir):
-        """Should use single input as light variant."""
+    def test_explicit_light_skips_generation(self, sample_icon, temp_output_dir):
+        """Providing --light should use that image, not generate."""
         # Save sample icon to temp file
-        input_path = temp_output_dir / "input.png"
-        sample_icon.save(str(input_path))
+        light_path = temp_output_dir / "light.png"
+        sample_icon.save(str(light_path))
 
         config = IconGeneratorConfig(
             platforms={Platform.IOS},
@@ -384,12 +384,28 @@ class TestIconGenerator:
         generator = IconGenerator(gemimg=None, config=config)
 
         result = generator.generate(
-            input_images=[input_path],
+            light=light_path,
         )
 
         assert result.api_calls == 0  # No generation needed
         assert result.variants.light is not None
         assert "ios/light" in result.output_paths
+
+    def test_input_images_are_style_references(self, sample_icon, temp_output_dir):
+        """Input images should be style references, requiring a prompt."""
+        # Save sample icon to temp file
+        ref_path = temp_output_dir / "ref.png"
+        sample_icon.save(str(ref_path))
+
+        config = IconGeneratorConfig(
+            platforms={Platform.IOS},
+            output_dir=temp_output_dir / "output",
+        )
+        generator = IconGenerator(gemimg=None, config=config)
+
+        # Should require prompt since input_images are references, not variants
+        with pytest.raises(ValueError, match="Prompt is required"):
+            generator.generate(input_images=[ref_path])
 
     def test_generate_requires_prompt_for_generation(self, temp_output_dir):
         """Should raise error if generation needed but no prompt."""

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -262,6 +262,23 @@ class TestIconVariants:
         assert variants.dark is not None
         assert variants.tinted is None
 
+    def test_has_any_variant_true(self, sample_icon):
+        """Should return True when at least one variant exists."""
+        variants = IconVariants(light=sample_icon)
+        assert variants.has_any_variant() is True
+
+    def test_has_any_variant_false(self):
+        """Should return False when no variants exist."""
+        variants = IconVariants()
+        assert variants.has_any_variant() is False
+
+    def test_count_variants(self, sample_icon):
+        """Should count non-None variants correctly."""
+        assert IconVariants().count() == 0
+        assert IconVariants(light=sample_icon).count() == 1
+        assert IconVariants(light=sample_icon, dark=sample_icon).count() == 2
+        assert IconVariants(light=sample_icon, dark=sample_icon, tinted=sample_icon).count() == 3
+
 
 class TestIconGeneratorConfig:
     """Tests for IconGeneratorConfig."""
@@ -285,6 +302,41 @@ class TestIconGeneratorConfig:
         assert config.icon_type == IconType.MENU_ICON
         assert len(config.platforms) == 2
         assert config.themed is True
+
+    def test_raises_on_empty_platforms(self):
+        """Should raise ValueError when platforms is empty."""
+        with pytest.raises(ValueError, match="At least one platform must be specified"):
+            IconGeneratorConfig(platforms=set())
+
+
+class TestIconType:
+    """Tests for IconType enum properties."""
+
+    def test_app_icon_requires_opaque_background(self):
+        """APP_ICON should require opaque background."""
+        assert IconType.APP_ICON.requires_opaque_background is True
+        assert IconType.APP_ICON.allows_transparency is False
+
+    def test_menu_icon_allows_transparency(self):
+        """MENU_ICON should allow transparency."""
+        assert IconType.MENU_ICON.requires_opaque_background is False
+        assert IconType.MENU_ICON.allows_transparency is True
+
+    def test_favicon_allows_transparency(self):
+        """FAVICON should allow transparency."""
+        assert IconType.FAVICON.requires_opaque_background is False
+        assert IconType.FAVICON.allows_transparency is True
+
+
+class TestVariantEnum:
+    """Tests for Variant enum."""
+
+    def test_all_variants_defined(self):
+        """All expected variants should be defined."""
+        from gemimg.icons import Variant
+        assert Variant.LIGHT.value == "light"
+        assert Variant.DARK.value == "dark"
+        assert Variant.TINTED.value == "tinted"
 
 
 class TestIconGenerator:
@@ -328,3 +380,36 @@ class TestIconGenerator:
         assert Platform.IOS in generator.config.platforms
         assert Platform.ANDROID in generator.config.platforms
         assert len(generator.config.platforms) == 2
+
+    def test_generate_raises_on_nonexistent_input_file(self, temp_output_dir):
+        """Should raise FileNotFoundError for non-existent input files."""
+        config = IconGeneratorConfig(
+            platforms={Platform.IOS},
+            output_dir=temp_output_dir / "output",
+        )
+        generator = IconGenerator(gemimg=None, config=config)
+
+        with pytest.raises(FileNotFoundError, match="Image file not found"):
+            generator.generate(input_images=[Path("/nonexistent/image.png")])
+
+    def test_generate_raises_on_nonexistent_variant_file(self, temp_output_dir):
+        """Should raise FileNotFoundError for non-existent variant files."""
+        config = IconGeneratorConfig(
+            platforms={Platform.IOS},
+            output_dir=temp_output_dir / "output",
+        )
+        generator = IconGenerator(gemimg=None, config=config)
+
+        with pytest.raises(FileNotFoundError, match="Image file not found"):
+            generator.generate(light=Path("/nonexistent/light.png"))
+
+    def test_generate_requires_gemimg_for_generation(self, temp_output_dir):
+        """Should raise ValueError when GemImg needed but not provided."""
+        config = IconGeneratorConfig(
+            platforms={Platform.IOS},
+            output_dir=temp_output_dir / "output",
+        )
+        generator = IconGenerator(gemimg=None, config=config)
+
+        with pytest.raises(ValueError, match="GemImg instance is required"):
+            generator.generate(prompt="test icon")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,51 @@
+"""Tests for utility functions."""
+
+import pytest
+from PIL import Image
+
+from gemimg.utils import _validate_aspect, resize_image
+
+
+class TestValidateAspect:
+    """Tests for aspect ratio validation."""
+
+    def test_valid_standard_aspect_ratios(self):
+        """Standard aspect ratios should be valid for all models."""
+        valid_ratios = ["1:1", "3:4", "4:3", "9:16", "16:9"]
+        for ratio in valid_ratios:
+            assert _validate_aspect(ratio, is_pro=False) == ratio
+            assert _validate_aspect(ratio, is_pro=True) == ratio
+
+    def test_all_aspect_ratios_valid_for_both_models(self):
+        """All aspect ratios should be valid for both flash and pro models."""
+        all_ratios = ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"]
+        for ratio in all_ratios:
+            # Should work for both flash and pro
+            assert _validate_aspect(ratio, is_pro=False) == ratio
+            assert _validate_aspect(ratio, is_pro=True) == ratio
+
+    def test_invalid_aspect_ratio(self):
+        """Invalid aspect ratios should raise ValueError."""
+        with pytest.raises(ValueError):
+            _validate_aspect("7:3", is_pro=False)
+        with pytest.raises(ValueError):
+            _validate_aspect("7:3", is_pro=True)
+
+
+class TestResizeImage:
+    """Tests for image resizing."""
+
+    def test_resize_preserves_aspect_ratio(self):
+        """Resize should preserve aspect ratio."""
+        img = Image.new("RGB", (200, 100), color="red")
+        resized = resize_image(img, 100)
+        # Should maintain 2:1 aspect ratio
+        assert resized.width == 100
+        assert resized.height == 50
+
+    def test_resize_square_image(self):
+        """Resize square image should produce square result."""
+        img = Image.new("RGB", (500, 500), color="blue")
+        resized = resize_image(img, 100)
+        assert resized.width == 100
+        assert resized.height == 100


### PR DESCRIPTION
# Add Gemini 3 support, Google Search, multi-image I/O, and icon generation (iOS/macOS/Android/Windows/PWA)

## TL;DR

**This PR adds:**
- **Gemini 3 Pro**: `--google-search` for real-time data, 14 input images (vs 6), 4K output
- **Icon Generation**: `gemimg icons "prompt"` → production-ready icons for iOS, macOS, Android, Windows, PWA
- **72 tests** (was 0), robust error handling, CLI improvements
- **Grid generation**: `gemimg "comic strip" --grid 2x2` (Pro models)
- **multi-image I/O**: accepts multiple images as input (plus a text prompt) and produces multiple output images (or just one)

## Breaking Changes

**None.** All existing CLI flags and behaviors preserved, except gemini 3 pro is now the default model.

## Quick Test

```bash
# Verify CLI works
gemimg --help
gemimg icons --help

# Run tests
uv run pytest tests/ -v
```

## Scope

```
15 files changed, +2,586 lines, -110 lines

Key additions:
  gemimg/icons/          - New module (1,006 lines)
  tests/                 - New test suite (963 lines)
  gemimg/__main__.py     - CLI restructure (+449 lines)
  gemimg/gemimg.py       - Gemini 3 + error handling (+89 lines)
```

---

## What's New

### 1. Gemini 3 Pro Image Support

| Feature | Flash | Pro | Gemini 3 |
|---------|-------|-----|----------|
| Resolution | 1024px | Up to 4096px | Up to 4096px |
| Input images | 6 max | 6 max | 14 max |
| Google Search | No | No | `--google-search` |

```bash
gemimg "current weather in Tokyo" --google-search --model gemini-3-pro-image-preview
```

### 2. App Icon Generation

One command generates 40+ platform-specific icons:

```bash
gemimg icons "robot mascot" --preset all
```

Output:
```
icons/
├── ios/light/      # 13 sizes, RGBA→RGB conversion
├── macos/light/    # 10 sizes, drop shadows, @2x
├── android/light/  # 6 densities, monochrome variant
├── windows/light/  # Multi-size ICO
└── pwa/light/      # Maskable + manifest.json
```

Options: `--preset mobile|desktop|apple|all`, `--themed` (light+dark+tinted), `--platforms ios android`

### 3. CLI Improvements

- Arguments grouped by function (Input/Output, Generation, API)
- `[Pro models only]` and `[Gemini 3 only]` markers in help
- Warnings when Pro-only options used with Flash (was silent)

### 4. Error Handling

- Specific messages for 401/403/429/5xx errors
- Graceful partial failures (keeps successful images if some fail)
- Defensive API response parsing

---

## CLI Options Reference

### Generate Command (`gemimg`)

| Option | Impact | Model Requirement |
|--------|--------|-------------------|
| `-i FILE...` | Provide style reference images for transformation | All (6 max), Gemini 3 (14 max) |
| `-n COUNT` | Generate multiple variations | All |
| `--aspect-ratio` | Control output dimensions (1:1, 16:9, 4:3, etc.) | All |
| `--temperature` | Creativity 0.0-2.0 (higher = more varied) | All |
| `--image-size` | Output resolution: 1K/2K/4K | Pro models |
| `--system-prompt` | Custom style instructions | Pro models |
| `--grid RxC` | Multi-panel grids (2x2, 3x3, etc.) | Pro models |
| `--google-search` | Real-time data grounding | Gemini 3 |

### Icons Command (`gemimg icons`)

| Option | Impact |
|--------|--------|
| `-o DIR` | Output directory (default: `icons/`) |
| `--platforms` | Select specific platforms (ios, macos, android, windows, pwa) |
| `--preset` | Quick platform bundles: `mobile`, `desktop`, `apple`, `all` |
| `--themed` | Generate light + dark + tinted variants |
| `--app-icon` / `--menu-icon` / `--favicon` | Output type (launcher, UI, web) |
| `--no-shadow` | Skip macOS drop shadow |
| `--no-safe-zone-check` | Skip Android safe zone validation |

---

## Limitations

- **API required** - No offline generation
- **macOS .icns** - Outputs PNGs; `iconutil` needed for bundle
- **No SVG** - Gemini outputs raster only

---

## Files Changed

| File | Change |
|------|--------|
| `gemimg/gemimg.py` | Gemini 3 detection, `--google-search`, error handling, warnings |
| `gemimg/__main__.py` | `icons` subcommand, argument groups, validators |
| `gemimg/icons/*.py` | Platform processors, constants, orchestration |
| `tests/test_*.py` | 72 tests for all new functionality |
| `README.md` | Gemini 3 documentation |

