### PR TITLE
add better CLI argument choices, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,30 @@ gemimg "A kitten with prominent purple-and-green fur."
 python -m gemimg "A kitten with prominent purple-and-green fur."
 ```
 
-Common options: `-i/--input-images`, `-o/--output-file`, `--aspect-ratio`, `--output-dir`, `-n` (number of images), `--webp`, `--store-prompt`, `-f/--force`. The API key can be provided via `--api-key` or the `GEMINI_API_KEY` environment variable.
+### CLI Options
+
+| Option                 | Description                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| `prompt`               | Text prompt for image generation (required)                                       |
+| `-i`, `--input-images` | Paths to input images for editing/compositing                                     |
+| `-o`, `--output-file`  | Output filename (defaults to `output.png`)                                        |
+| `--api-key`            | Gemini API key (or set `GEMINI_API_KEY` env var)                                  |
+| `--model`              | `2.5-flash` (default), `3-pro`, `3.1-flash`                                       |
+| `--aspect-ratio`       | `1:1` (default), `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9` |
+| `--output-dir`         | Directory to save generated images                                                |
+| `-n`                   | Number of images to generate                                                      |
+| `--webp`               | Save as WEBP instead of PNG                                                       |
+| `--store-prompt`       | Store the prompt in image metadata                                                |
+| `-f`, `--force`        | Force overwrite existing files                                                    |
+| `--temperature`        | Generation temperature (default: `1.0`)                                           |
+| `--no-resize`          | Do not resize input images                                                        |
+| `--image-size`         | `1K`, `2K` (default), `4K` — Pro models only                                      |
+| `--system-prompt`      | System prompt — Pro models only                                                   |
+| `--grid`               | Grid dimensions, e.g., `2x2` — Pro models only                                    |
+| `--grid-aspect-ratio`  | Aspect ratio for grid cells (same options as `--aspect-ratio`)                    |
+| `--grid-image-size`    | `1K`, `2K` (default), `4K`                                                        |
+| `--save-grid-original` | Save the original grid image before slicing                                       |
+| `--base-url`           | Alternative Gemini API endpoint                                                   |
 
 ## Gemini 2.5 Flash Image Model Notes
 

--- a/gemimg/__main__.py
+++ b/gemimg/__main__.py
@@ -6,11 +6,18 @@ from .gemimg import GemImg
 from .grid import Grid
 from .utils import save_image
 
+MODEL_ALIASES = {
+    "2.5-flash": "gemini-2.5-flash-image",
+    "3-pro": "gemini-3-pro-image-preview",
+    "3.1-flash": "gemini-3.1-flash-image-preview",
+}
+
 
 def main():
     """CLI for generating images with GemImg."""
     parser = argparse.ArgumentParser(
-        description="Generate images using the Gemini API."
+        description="Generate images using the Gemini API.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     parser.add_argument("prompt", help="The text prompt for image generation.")
@@ -29,11 +36,14 @@ def main():
     )
     parser.add_argument(
         "--api-key",
-        default=os.getenv("GEMINI_API_KEY"),
-        help="API key for the Gemini API. Defaults to the GEMINI_API_KEY environment variable.",
+        default=None,
+        help="API key for the Gemini API. Falls back to GEMINI_API_KEY env var.",
     )
     parser.add_argument(
-        "--model", default="gemini-2.5-flash-image", help="The model to use."
+        "--model",
+        default="2.5-flash",
+        choices=["2.5-flash", "3-pro", "3.1-flash", "gemini-2.5-flash-image", "gemini-3-pro-image-preview", "gemini-3.1-flash-image-preview"],
+        help="The model to use for image generation.",
     )
     parser.add_argument(
         "--base-url",
@@ -41,7 +51,10 @@ def main():
         help="Alternative Gemini API endpoint for your organization.",
     )
     parser.add_argument(
-        "--aspect-ratio", default="1:1", help="Aspect ratio of the generated image."
+        "--aspect-ratio",
+        default="1:1",
+        choices=["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        help="Aspect ratio of the generated image.",
     )
     parser.add_argument(
         "--no-resize",
@@ -67,27 +80,30 @@ def main():
     parser.add_argument(
         "--image-size",
         default="2K",
-        help="Image size for the generation (Pro models only).",
+        choices=["1K", "2K", "4K"],
+        help="Image size (Pro models only).",
     )
     parser.add_argument(
         "--system-prompt",
         default=None,
-        help="System prompt for the generation (Pro models only).",
+        help="System prompt (Pro models only).",
     )
     parser.add_argument(
         "--grid",
         default=None,
-        help="Grid dimensions as ROWSxCOLS (e.g., 2x2). Pro models only.",
+        help="Grid dimensions as ROWSxCOLS, e.g., 2x2 (Pro models only).",
     )
     parser.add_argument(
         "--grid-aspect-ratio",
         default="1:1",
-        help="Aspect ratio for grid cells (default: 1:1).",
+        choices=["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        help="Aspect ratio for grid cells.",
     )
     parser.add_argument(
         "--grid-image-size",
         default="2K",
-        help="Image size for grid generation (default: 2K).",
+        choices=["1K", "2K", "4K"],
+        help="Image size for grid generation.",
     )
     parser.add_argument(
         "--save-grid-original",
@@ -103,7 +119,9 @@ def main():
 
     args = parser.parse_args()
 
-    if not args.api_key:
+    # Fall back to env var for API key
+    api_key = args.api_key or os.getenv("GEMINI_API_KEY")
+    if not api_key:
         parser.error(
             "API key is required. Provide it with --api-key or set the GEMINI_API_KEY environment variable."
         )
@@ -113,7 +131,10 @@ def main():
     else:
         base_url = "https://generativelanguage.googleapis.com"
 
-    gem_img = GemImg(api_key=args.api_key, model=args.model, base_url=base_url)
+    # Resolve model alias to full model name
+    model = MODEL_ALIASES.get(args.model, args.model)
+
+    gem_img = GemImg(api_key=api_key, model=model, base_url=base_url)
 
     # Parse grid dimensions if provided
     grid = None


### PR DESCRIPTION
The available model keys were never described. This now gives the choices in argparse so the users can see which model names are supported. Also adds model aliases so you do not have to type out the full thing. The same for aspect ratios which were previously undocumented.

README has been updated with all the options now.

The CLI now prints:

```
➜ uv run gemimg --help
usage: gemimg [-h] [-i INPUT_IMAGES [INPUT_IMAGES ...]] [-o OUTPUT_FILE] [--api-key API_KEY]
              [--model {2.5-flash,3-pro,gemini-2.5-flash-image,gemini-3-pro-image-preview}] [--base-url BASE_URL]
              [--aspect-ratio {1:1,2:3,3:2,3:4,4:3,4:5,5:4,9:16,16:9,21:9}] [--no-resize] [--output-dir OUTPUT_DIR]
              [--temperature TEMPERATURE] [--webp] [-n N] [--store-prompt] [--image-size {1K,2K,4K}]
              [--system-prompt SYSTEM_PROMPT] [--grid GRID]
              [--grid-aspect-ratio {1:1,2:3,3:2,3:4,4:3,4:5,5:4,9:16,16:9,21:9}] [--grid-image-size {1K,2K,4K}]
              [--save-grid-original] [-f]
              prompt

Generate images using the Gemini API.

positional arguments:
  prompt                The text prompt for image generation.

options:
  -h, --help            show this help message and exit
  -i, --input-images INPUT_IMAGES [INPUT_IMAGES ...]
                        Optional paths to input images. (default: [])
  -o, --output-file OUTPUT_FILE
                        Optional output filename. Defaults to output.png, output-2.png, etc. (default: None)
  --api-key API_KEY     API key for the Gemini API. Defaults to the GEMINI_API_KEY environment variable. (default:
                        AIzaSyBgGRYy6t9EaXXPBaycXSn26ObX7C2T4-U)
  --model {2.5-flash,3-pro,gemini-2.5-flash-image,gemini-3-pro-image-preview}
                        The model to use for image generation. (default: 2.5-flash)
  --base-url BASE_URL   Alternative Gemini API endpoint for your organization. (default: None)
  --aspect-ratio {1:1,2:3,3:2,3:4,4:3,4:5,5:4,9:16,16:9,21:9}
                        Aspect ratio of the generated image. (default: 1:1)
  --no-resize           Do not resize input images. (default: True)
  --output-dir OUTPUT_DIR
                        Directory to save the generated images. (default: )
  --temperature TEMPERATURE
                        Generation temperature. (default: 1.0)
  --webp                Save as WEBP instead of PNG. (default: False)
  -n N                  Number of images to generate. (default: 1)
  --store-prompt        Store the prompt in the image metadata. (default: False)
  --image-size {1K,2K,4K}
                        Image size (Pro models only). (default: 2K)
  --system-prompt SYSTEM_PROMPT
                        System prompt (Pro models only). (default: None)
  --grid GRID           Grid dimensions as ROWSxCOLS, e.g., 2x2 (Pro models only). (default: None)
  --grid-aspect-ratio {1:1,2:3,3:2,3:4,4:3,4:5,5:4,9:16,16:9,21:9}
                        Aspect ratio for grid cells. (default: 1:1)
  --grid-image-size {1K,2K,4K}
                        Image size for grid generation. (default: 2K)
  --save-grid-original  Save the original grid image before slicing. (default: False)
  -f, --force           Force overwrite of existing files. (default: False)
```